### PR TITLE
Rename _SCHEMA to s_schema and make it private

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/github/license/sadicangel/avro-source-generator)](LICENSE)
 [![Build](https://img.shields.io/github/actions/workflow/status/sadicangel/avro-source-generator/build.yml?label=build)](https://github.com/sadicangel/avro-source-generator/actions)
 
-![Avro Source Generator](icon.png)
+![Avro Source Generator](https://raw.githubusercontent.com/sadicangel/avro-source-generator/refs/heads/main/icon.png)
 
 Avro Source Generator is a .NET source generator that generates C# code from Avro schemas and is compatible with Apache Avro.
 
@@ -84,8 +84,8 @@ namespace example
         public string? Email { get; init; }
         public required global::System.DateTime CreatedAt { get; init; }
     
-        public global::Avro.Schema Schema { get => User._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse("""
+        public global::Avro.Schema Schema { get => User.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse("""
         {
           "type": "record",
           "name": "User",
@@ -250,6 +250,8 @@ public partial record User;
 ```
 
 ## Limitations
+
+### `partial enum`
 In C#, `enum` types cannot be declared as `partial`, so it's not possible to configure code generation for just a single `enum` type.  
 A possible workaround for this is to wrap the `enum` schema in a `record` schema.
 
@@ -345,4 +347,4 @@ Contributions are welcome! If you have any ideas, suggestions, or bug reports, p
 
 ## License
 
-This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License. See the [LICENSE](https://github.com/sadicangel/avro-source-generator/blob/main/LICENSE) file for details.

--- a/src/AvroSourceGenerator/Templates/error.sbncs
+++ b/src/AvroSourceGenerator/Templates/error.sbncs
@@ -4,8 +4,8 @@
     {{ include 'field' field: field }}
     {{~ end ~}}
     
-    public override global::Avro.Schema Schema { get => {{ $.schema.CSharpName.Name }}._SCHEMA; }
-    public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+    public override global::Avro.Schema Schema { get => {{ $.schema.CSharpName.Name }}.s_schema; }
+    private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
     {{ $.schema | json }});
 
     {{ include 'getput' schema: $.schema override: true ~}}

--- a/src/AvroSourceGenerator/Templates/fixed.sbncs
+++ b/src/AvroSourceGenerator/Templates/fixed.sbncs
@@ -4,7 +4,7 @@
 
     public uint Size { get => (uint)Value.Length; }
 
-    public override global::Avro.Schema Schema { get => {{ $.schema.CSharpName.Name }}._SCHEMA; }
-    public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+    public override global::Avro.Schema Schema { get => {{ $.schema.CSharpName.Name }}.s_schema; }
+    private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
     {{ $.schema | json }});
 }

--- a/src/AvroSourceGenerator/Templates/record.sbncs
+++ b/src/AvroSourceGenerator/Templates/record.sbncs
@@ -4,8 +4,8 @@
     {{ include 'field' field: field }}
     {{~ end ~}}
 
-    public global::Avro.Schema Schema { get => {{ $.schema.CSharpName.Name }}._SCHEMA; }
-    public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+    public global::Avro.Schema Schema { get => {{ $.schema.CSharpName.Name }}.s_schema; }
+    private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
     {{ $.schema | json }});
 
     {{ include 'getput' schema: $.schema override: false ~}}

--- a/tests/AvroSourceGenerator.IntegrationTests/AvroSchemaTests.cs
+++ b/tests/AvroSourceGenerator.IntegrationTests/AvroSchemaTests.cs
@@ -23,7 +23,7 @@ public sealed class AvroSchemaTests
     private static Avro.Schema GetGeneratedTypeSchema(string typeName)
     {
         var type = Type.GetType($"AvroSourceGenerator.IntegrationTests.Schemas.{typeName}", throwOnError: true)!;
-        var field = type.GetField("_SCHEMA", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)!;
+        var field = type.GetField("s_schema", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)!;
         return (Avro.Schema)field.GetValue(null)!;
     }
 }

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AliasesTests/AliasesTests.Verify_aliases=Alias1,Alias2_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AliasesTests/AliasesTests.Verify_aliases=Alias1,Alias2_schemaType=error.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     public partial class Error : global::Avro.Specific.SpecificException
     {
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AliasesTests/AliasesTests.Verify_aliases=Alias1,Alias2_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AliasesTests/AliasesTests.Verify_aliases=Alias1,Alias2_schemaType=fixed.verified.txt
@@ -10,8 +10,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AliasesTests/AliasesTests.Verify_aliases=Alias1,Alias2_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AliasesTests/AliasesTests.Verify_aliases=Alias1,Alias2_schemaType=record.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AliasesTests/AliasesTests.Verify_aliases=[]_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AliasesTests/AliasesTests.Verify_aliases=[]_schemaType=error.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial class Error : global::Avro.Specific.SpecificException
     {
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AliasesTests/AliasesTests.Verify_aliases=[]_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AliasesTests/AliasesTests.Verify_aliases=[]_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AliasesTests/AliasesTests.Verify_aliases=[]_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AliasesTests/AliasesTests.Verify_aliases=[]_schemaType=record.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AliasesTests/AliasesTests.Verify_aliases=null_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AliasesTests/AliasesTests.Verify_aliases=null_schemaType=error.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial class Error : global::Avro.Specific.SpecificException
     {
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AliasesTests/AliasesTests.Verify_aliases=null_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AliasesTests/AliasesTests.Verify_aliases=null_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AliasesTests/AliasesTests.Verify_aliases=null_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AliasesTests/AliasesTests.Verify_aliases=null_schemaType=record.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeAccessModifierTests/AttributeAccessModifierTests.Verify_accessModifier=_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeAccessModifierTests/AttributeAccessModifierTests.Verify_accessModifier=_schemaType=error.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     internal partial class Error : global::Avro.Specific.SpecificException
     {
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeAccessModifierTests/AttributeAccessModifierTests.Verify_accessModifier=_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeAccessModifierTests/AttributeAccessModifierTests.Verify_accessModifier=_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeAccessModifierTests/AttributeAccessModifierTests.Verify_accessModifier=_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeAccessModifierTests/AttributeAccessModifierTests.Verify_accessModifier=_schemaType=record.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     internal partial class Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeAccessModifierTests/AttributeAccessModifierTests.Verify_accessModifier=file_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeAccessModifierTests/AttributeAccessModifierTests.Verify_accessModifier=file_schemaType=error.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     file partial class Error : global::Avro.Specific.SpecificException
     {
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeAccessModifierTests/AttributeAccessModifierTests.Verify_accessModifier=file_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeAccessModifierTests/AttributeAccessModifierTests.Verify_accessModifier=file_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeAccessModifierTests/AttributeAccessModifierTests.Verify_accessModifier=file_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeAccessModifierTests/AttributeAccessModifierTests.Verify_accessModifier=file_schemaType=record.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     file partial class Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeAccessModifierTests/AttributeAccessModifierTests.Verify_accessModifier=internal_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeAccessModifierTests/AttributeAccessModifierTests.Verify_accessModifier=internal_schemaType=error.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     internal partial class Error : global::Avro.Specific.SpecificException
     {
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeAccessModifierTests/AttributeAccessModifierTests.Verify_accessModifier=internal_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeAccessModifierTests/AttributeAccessModifierTests.Verify_accessModifier=internal_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeAccessModifierTests/AttributeAccessModifierTests.Verify_accessModifier=internal_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeAccessModifierTests/AttributeAccessModifierTests.Verify_accessModifier=internal_schemaType=record.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     internal partial class Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeAccessModifierTests/AttributeAccessModifierTests.Verify_accessModifier=public_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeAccessModifierTests/AttributeAccessModifierTests.Verify_accessModifier=public_schemaType=error.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial class Error : global::Avro.Specific.SpecificException
     {
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeAccessModifierTests/AttributeAccessModifierTests.Verify_accessModifier=public_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeAccessModifierTests/AttributeAccessModifierTests.Verify_accessModifier=public_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeAccessModifierTests/AttributeAccessModifierTests.Verify_accessModifier=public_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeAccessModifierTests/AttributeAccessModifierTests.Verify_accessModifier=public_schemaType=record.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial class Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeFullNameTests/AttributeFullNameTests.Verify.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeFullNameTests/AttributeFullNameTests.Verify.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     internal partial class Example : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Example._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Example.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=error.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public string Field { get; init; }
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"error\",\"name\":\"Error\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     
         public override object? Get(int fieldPos)

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"fixed\",\"name\":\"Fixed\",\"namespace\":\"SchemaNamespace\",\"size\":16}");
     }
 

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=record.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public string Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     
         public object? Get(int fieldPos)

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=error.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required string Field { get; init; }
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=record.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required string Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=error.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required string Field { get; init; }
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=record.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required string Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=error.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required string Field { get; init; }
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=record.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required string Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=error.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     {
         public string Field { get; set; }
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"error\",\"name\":\"Error\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     
         public override object Get(int fieldPos)

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"fixed\",\"name\":\"Fixed\",\"namespace\":\"SchemaNamespace\",\"size\":16}");
     }
 

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=record.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     {
         public string Field { get; set; }
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     
         public object Get(int fieldPos)

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=error.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public string Field { get; set; }
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"error\",\"name\":\"Error\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     
         public override object? Get(int fieldPos)

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"fixed\",\"name\":\"Fixed\",\"namespace\":\"SchemaNamespace\",\"size\":16}");
     }
 

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=record.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public string Field { get; set; }
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     
         public object? Get(int fieldPos)

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=error.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public string Field { get; set; }
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"error\",\"name\":\"Error\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     
         public override object? Get(int fieldPos)

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"fixed\",\"name\":\"Fixed\",\"namespace\":\"SchemaNamespace\",\"size\":16}");
     }
 

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeLanguageFeaturesTests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=record.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public string Field { get; set; }
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     
         public object? Get(int fieldPos)

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeRecordDeclarationTests/AttributeRecordDeclarationTests.Verify_recordDeclaration=class_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeRecordDeclarationTests/AttributeRecordDeclarationTests.Verify_recordDeclaration=class_schemaType=record.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial class Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/AttributeRecordDeclarationTests/AttributeRecordDeclarationTests.Verify_recordDeclaration=record_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/AttributeRecordDeclarationTests/AttributeRecordDeclarationTests.Verify_recordDeclaration=record_schemaType=record.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=error.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     internal partial class Error : global::Avro.Specific.SpecificException
     {
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=record.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     internal partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=error.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial class Error : global::Avro.Specific.SpecificException
     {
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=record.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=error.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial class Error : global::Avro.Specific.SpecificException
     {
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=record.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=error.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public string Field { get; init; }
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"error\",\"name\":\"Error\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     
         public override object? Get(int fieldPos)

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"fixed\",\"name\":\"Fixed\",\"namespace\":\"SchemaNamespace\",\"size\":16}");
     }
 

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=record.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public string Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     
         public object? Get(int fieldPos)

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=error.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required string Field { get; init; }
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=record.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required string Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=error.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required string Field { get; init; }
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=record.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required string Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=error.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required string Field { get; init; }
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=record.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required string Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=error.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     {
         public string Field { get; set; }
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"error\",\"name\":\"Error\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     
         public override object Get(int fieldPos)

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"fixed\",\"name\":\"Fixed\",\"namespace\":\"SchemaNamespace\",\"size\":16}");
     }
 

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=record.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     {
         public string Field { get; set; }
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     
         public object Get(int fieldPos)

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=error.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public string Field { get; set; }
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"error\",\"name\":\"Error\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     
         public override object? Get(int fieldPos)

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"fixed\",\"name\":\"Fixed\",\"namespace\":\"SchemaNamespace\",\"size\":16}");
     }
 

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=record.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public string Field { get; set; }
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     
         public object? Get(int fieldPos)

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=error.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public string Field { get; set; }
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"error\",\"name\":\"Error\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     
         public override object? Get(int fieldPos)

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"fixed\",\"name\":\"Fixed\",\"namespace\":\"SchemaNamespace\",\"size\":16}");
     }
 

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=record.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public string Field { get; set; }
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     
         public object? Get(int fieldPos)

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=error.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required string Field { get; init; }
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=record.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required string Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojRecordDeclarationTests/CsprojRecordDeclarationTests.Verify_recordDeclaration=class_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojRecordDeclarationTests/CsprojRecordDeclarationTests.Verify_recordDeclaration=class_schemaType=record.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial class Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojRecordDeclarationTests/CsprojRecordDeclarationTests.Verify_recordDeclaration=invalid_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojRecordDeclarationTests/CsprojRecordDeclarationTests.Verify_recordDeclaration=invalid_schemaType=record.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojRecordDeclarationTests/CsprojRecordDeclarationTests.Verify_recordDeclaration=record_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojRecordDeclarationTests/CsprojRecordDeclarationTests.Verify_recordDeclaration=record_schemaType=record.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests/DocumentationTests.Verify_doc=Multi-line-comment_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests/DocumentationTests.Verify_doc=Multi-line-comment_schemaType=error.verified.txt
@@ -12,8 +12,8 @@ namespace SchemaNamespace
     public partial class Error : global::Avro.Specific.SpecificException
     {
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests/DocumentationTests.Verify_doc=Multi-line-comment_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests/DocumentationTests.Verify_doc=Multi-line-comment_schemaType=fixed.verified.txt
@@ -14,8 +14,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests/DocumentationTests.Verify_doc=Multi-line-comment_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests/DocumentationTests.Verify_doc=Multi-line-comment_schemaType=record.verified.txt
@@ -12,8 +12,8 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests/DocumentationTests.Verify_doc=Single line comment_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests/DocumentationTests.Verify_doc=Single line comment_schemaType=error.verified.txt
@@ -10,8 +10,8 @@ namespace SchemaNamespace
     public partial class Error : global::Avro.Specific.SpecificException
     {
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests/DocumentationTests.Verify_doc=Single line comment_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests/DocumentationTests.Verify_doc=Single line comment_schemaType=fixed.verified.txt
@@ -12,8 +12,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests/DocumentationTests.Verify_doc=Single line comment_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests/DocumentationTests.Verify_doc=Single line comment_schemaType=record.verified.txt
@@ -10,8 +10,8 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests/DocumentationTests.Verify_doc=_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests/DocumentationTests.Verify_doc=_schemaType=error.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial class Error : global::Avro.Specific.SpecificException
     {
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests/DocumentationTests.Verify_doc=_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests/DocumentationTests.Verify_doc=_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests/DocumentationTests.Verify_doc=_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests/DocumentationTests.Verify_doc=_schemaType=record.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests/DocumentationTests.Verify_doc=null_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests/DocumentationTests.Verify_doc=null_schemaType=error.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial class Error : global::Avro.Specific.SpecificException
     {
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests/DocumentationTests.Verify_doc=null_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests/DocumentationTests.Verify_doc=null_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests/DocumentationTests.Verify_doc=null_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests/DocumentationTests.Verify_doc=null_schemaType=record.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Default_type=boolean_value=true.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Default_type=boolean_value=true.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public bool Field { get; init; } = true;
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Default_type=bytes_value=--u0034-u0032-.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Default_type=bytes_value=--u0034-u0032-.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public byte[] Field { get; init; } = [0x34, 0x32];
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Default_type=double_value=42.0.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Default_type=double_value=42.0.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public double Field { get; init; } = 42.0;
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Default_type=float_value=42.0.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Default_type=float_value=42.0.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public float Field { get; init; } = 42.0f;
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Default_type=int_value=42.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Default_type=int_value=42.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public int Field { get; init; } = 42;
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Default_type=long_value=42.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Default_type=long_value=42.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public long Field { get; init; } = 42;
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Default_type=null_value=null.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Default_type=null_value=null.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required object Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Default_type=string_value=-FortyTwo-.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Default_type=string_value=-FortyTwo-.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public string Field { get; init; } = "FortyTwo";
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Enum_Nullable_class=error#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Enum_Nullable_class=error#01.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
         public required global::SchemaNamespace.Enum Field { get; init; }
         public global::SchemaNamespace.Enum? NullableField { get; init; }
         
-        public override global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Enum_Nullable_class=record#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Enum_Nullable_class=record#01.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
         public required global::SchemaNamespace.Enum Field { get; init; }
         public global::SchemaNamespace.Enum? NullableField { get; init; }
     
-        public global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Enum_class=error#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Enum_class=error#01.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required global::SchemaNamespace.Enum Field { get; init; }
         
-        public override global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Enum_class=record#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Enum_class=record#01.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required global::SchemaNamespace.Enum Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=error_field=boolean.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=error_field=boolean.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public bool? Field { get; init; }
         
-        public override global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=error_field=bytes.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=error_field=bytes.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public byte[]? Field { get; init; }
         
-        public override global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=error_field=double.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=error_field=double.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public double? Field { get; init; }
         
-        public override global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=error_field=float.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=error_field=float.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public float? Field { get; init; }
         
-        public override global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=error_field=int.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=error_field=int.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public int? Field { get; init; }
         
-        public override global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=error_field=long.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=error_field=long.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public long? Field { get; init; }
         
-        public override global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=error_field=null.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=error_field=null.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public object? Field { get; init; }
         
-        public override global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=error_field=string.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=error_field=string.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public string? Field { get; init; }
         
-        public override global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=record_field=boolean.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=record_field=boolean.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public bool? Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=record_field=bytes.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=record_field=bytes.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public byte[]? Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=record_field=double.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=record_field=double.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public double? Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=record_field=float.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=record_field=float.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public float? Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=record_field=int.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=record_field=int.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public int? Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=record_field=long.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=record_field=long.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public long? Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=record_field=null.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=record_field=null.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public object? Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=record_field=string.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_Nullable_class=record_field=string.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public string? Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=error_field=boolean.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=error_field=boolean.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required bool Field { get; init; }
         
-        public override global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=error_field=bytes.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=error_field=bytes.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required byte[] Field { get; init; }
         
-        public override global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=error_field=double.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=error_field=double.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required double Field { get; init; }
         
-        public override global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=error_field=float.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=error_field=float.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required float Field { get; init; }
         
-        public override global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=error_field=int.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=error_field=int.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required int Field { get; init; }
         
-        public override global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=error_field=long.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=error_field=long.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required long Field { get; init; }
         
-        public override global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=error_field=null.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=error_field=null.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required object Field { get; init; }
         
-        public override global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=error_field=string.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=error_field=string.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required string Field { get; init; }
         
-        public override global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=record_field=boolean.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=record_field=boolean.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required bool Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=record_field=bytes.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=record_field=bytes.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required byte[] Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=record_field=double.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=record_field=double.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required double Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=record_field=float.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=record_field=float.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required float Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=record_field=int.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=record_field=int.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required int Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=record_field=long.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=record_field=long.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required long Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=record_field=null.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=record_field=null.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required object Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=record_field=string.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldTests/FieldTests.Verify_Primitive_class=record_field=string.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required string Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Class._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Class.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FixedSizeTests/FixedSizeTests.Verify_size=32.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FixedSizeTests/FixedSizeTests.Verify_size=32.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FullNameTests/FullNameTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FullNameTests/FullNameTests.Verify#01.verified.txt
@@ -12,8 +12,8 @@ namespace @explicit
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Simple._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Simple.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FullNameTests/FullNameTests.Verify#03.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FullNameTests/FullNameTests.Verify#03.verified.txt
@@ -11,8 +11,8 @@ namespace a.full
     {
         public required global::a.full.Understanding inheritNamespace { get; init; }
     
-        public global::Avro.Schema Schema { get => Name._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Name.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FullNameTests/FullNameTests.Verify#04.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FullNameTests/FullNameTests.Verify#04.verified.txt
@@ -11,8 +11,8 @@
         public required global::@explicit.Simple explicitNamespace { get; init; }
         public required global::a.full.Name fullName { get; init; }
     
-        public global::Avro.Schema Schema { get => Example._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Example.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Date.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Date.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required global::System.DateTime DateField { get; init; }
     
-        public global::Avro.Schema Schema { get => Container._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Container.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Decimal_Bytes.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Decimal_Bytes.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required global::Avro.AvroDecimal DecimalField { get; init; }
     
-        public global::Avro.Schema Schema { get => Container._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Container.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Decimal_Fixed#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Decimal_Fixed#00.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Decimal._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Decimal.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Decimal_Fixed#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Decimal_Fixed#01.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required global::Avro.AvroDecimal DecimalField { get; init; }
     
-        public global::Avro.Schema Schema { get => Container._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Container.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Duration.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Duration.verified.txt
@@ -7,8 +7,8 @@
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Duration._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Duration.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Local_Timestamp_Microseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Local_Timestamp_Microseconds.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required global::System.DateTime TimestampField { get; init; }
     
-        public global::Avro.Schema Schema { get => Container._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Container.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Local_Timestamp_Milliseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Local_Timestamp_Milliseconds.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required global::System.DateTime TimestampField { get; init; }
     
-        public global::Avro.Schema Schema { get => Container._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Container.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Time_Microseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Time_Microseconds.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required global::System.TimeSpan TimeField { get; init; }
     
-        public global::Avro.Schema Schema { get => Container._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Container.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Time_Milliseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Time_Milliseconds.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required global::System.TimeSpan TimeField { get; init; }
     
-        public global::Avro.Schema Schema { get => Container._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Container.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Timestamp_Microseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Timestamp_Microseconds.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required global::System.DateTime TimestampField { get; init; }
     
-        public global::Avro.Schema Schema { get => Container._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Container.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Timestamp_Milliseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Timestamp_Milliseconds.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required global::System.DateTime TimestampField { get; init; }
     
-        public global::Avro.Schema Schema { get => Container._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Container.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Uuid_Fixed#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Uuid_Fixed#00.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Uuid._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Uuid.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Uuid_Fixed#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Uuid_Fixed#01.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required global::System.Guid UuidField { get; init; }
     
-        public global::Avro.Schema Schema { get => Container._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Container.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Uuid_String.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests/LogicalTests.Verify_Uuid_String.verified.txt
@@ -8,8 +8,8 @@ namespace SchemaNamespace
     {
         public required global::System.Guid UuidField { get; init; }
     
-        public global::Avro.Schema Schema { get => Container._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Container.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NameTests/NameTests.Verify_name=PascalCase_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NameTests/NameTests.Verify_name=PascalCase_schemaType=error.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial class PascalCase : global::Avro.Specific.SpecificException
     {
         
-        public override global::Avro.Schema Schema { get => PascalCase._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => PascalCase.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NameTests/NameTests.Verify_name=PascalCase_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NameTests/NameTests.Verify_name=PascalCase_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => PascalCase._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => PascalCase.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NameTests/NameTests.Verify_name=PascalCase_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NameTests/NameTests.Verify_name=PascalCase_schemaType=record.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial record PascalCase : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => PascalCase._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => PascalCase.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NameTests/NameTests.Verify_name=object_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NameTests/NameTests.Verify_name=object_schemaType=error.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial class @object : global::Avro.Specific.SpecificException
     {
         
-        public override global::Avro.Schema Schema { get => @object._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => @object.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NameTests/NameTests.Verify_name=object_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NameTests/NameTests.Verify_name=object_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => @object._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => @object.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NameTests/NameTests.Verify_name=object_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NameTests/NameTests.Verify_name=object_schemaType=record.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial record @object : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => @object._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => @object.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NameTests/NameTests.Verify_name=snake_case_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NameTests/NameTests.Verify_name=snake_case_schemaType=error.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial class snake_case : global::Avro.Specific.SpecificException
     {
         
-        public override global::Avro.Schema Schema { get => snake_case._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => snake_case.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NameTests/NameTests.Verify_name=snake_case_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NameTests/NameTests.Verify_name=snake_case_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => snake_case._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => snake_case.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NameTests/NameTests.Verify_name=snake_case_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NameTests/NameTests.Verify_name=snake_case_schemaType=record.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial record snake_case : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => snake_case._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => snake_case.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests/NamespaceTests.Verify_namespace=PascalCase.snake_case.object_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests/NamespaceTests.Verify_namespace=PascalCase.snake_case.object_schemaType=error.verified.txt
@@ -7,8 +7,8 @@ namespace PascalCase.snake_case.@object
     public partial class Error : global::Avro.Specific.SpecificException
     {
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests/NamespaceTests.Verify_namespace=PascalCase.snake_case.object_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests/NamespaceTests.Verify_namespace=PascalCase.snake_case.object_schemaType=fixed.verified.txt
@@ -9,8 +9,8 @@ namespace PascalCase.snake_case.@object
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests/NamespaceTests.Verify_namespace=PascalCase.snake_case.object_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests/NamespaceTests.Verify_namespace=PascalCase.snake_case.object_schemaType=record.verified.txt
@@ -7,8 +7,8 @@ namespace PascalCase.snake_case.@object
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests/NamespaceTests.Verify_namespace=_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests/NamespaceTests.Verify_namespace=_schemaType=error.verified.txt
@@ -5,8 +5,8 @@
     public partial class Error : global::Avro.Specific.SpecificException
     {
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests/NamespaceTests.Verify_namespace=_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests/NamespaceTests.Verify_namespace=_schemaType=fixed.verified.txt
@@ -7,8 +7,8 @@
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests/NamespaceTests.Verify_namespace=_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests/NamespaceTests.Verify_namespace=_schemaType=record.verified.txt
@@ -5,8 +5,8 @@
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests/NamespaceTests.Verify_namespace=null_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests/NamespaceTests.Verify_namespace=null_schemaType=error.verified.txt
@@ -5,8 +5,8 @@
     public partial class Error : global::Avro.Specific.SpecificException
     {
         
-        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "error",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests/NamespaceTests.Verify_namespace=null_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests/NamespaceTests.Verify_namespace=null_schemaType=fixed.verified.txt
@@ -7,8 +7,8 @@
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests/NamespaceTests.Verify_namespace=null_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests/NamespaceTests.Verify_namespace=null_schemaType=record.verified.txt
@@ -5,8 +5,8 @@
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/SchemaReferenceTests/SchemaReferenceTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/SchemaReferenceTests/SchemaReferenceTests.Verify#00.verified.txt
@@ -7,8 +7,8 @@ namespace This.Is.A.Full
     public partial record Name : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Name._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Name.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/SchemaReferenceTests/SchemaReferenceTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/SchemaReferenceTests/SchemaReferenceTests.Verify#01.verified.txt
@@ -11,8 +11,8 @@ namespace This.Is.A.Full
         /// </summary>
         public required global::This.Is.A.Full.Name Field4 { get; init; }
     
-        public global::Avro.Schema Schema { get => OtherName._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => OtherName.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/SchemaReferenceTests/SchemaReferenceTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/SchemaReferenceTests/SchemaReferenceTests.Verify#02.verified.txt
@@ -11,8 +11,8 @@
         public required global::This.Is.A.Full.Name Field2 { get; init; }
         public required global::This.Is.A.Full.OtherName Field3 { get; init; }
     
-        public global::Avro.Schema Schema { get => Wrapper._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Wrapper.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/SelfContainedSchemaTests/SelfContainedSchemaTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/SelfContainedSchemaTests/SelfContainedSchemaTests.Verify#00.verified.txt
@@ -8,8 +8,8 @@ namespace Namespace1
     {
         public required string field1 { get; init; }
     
-        public global::Avro.Schema Schema { get => Record1._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record1.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/SelfContainedSchemaTests/SelfContainedSchemaTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/SelfContainedSchemaTests/SelfContainedSchemaTests.Verify#01.verified.txt
@@ -11,8 +11,8 @@ namespace Namespace1
     {
         public required global::Namespace1.Record1 field1 { get; init; }
     
-        public global::Avro.Schema Schema { get => Record2._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record2.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnnamedRootSchemasTests/UnnamedRootSchemasTests.Verify_schemaType=[null, record].verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnnamedRootSchemasTests/UnnamedRootSchemasTests.Verify_schemaType=[null, record].verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnnamedRootSchemasTests/UnnamedRootSchemasTests.Verify_schemaType=array-record-.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnnamedRootSchemasTests/UnnamedRootSchemasTests.Verify_schemaType=array-record-.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnnamedRootSchemasTests/UnnamedRootSchemasTests.Verify_schemaType=map-record-.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnnamedRootSchemasTests/UnnamedRootSchemasTests.Verify_schemaType=map-record-.verified.txt
@@ -7,8 +7,8 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public global::Avro.Schema Schema { get => Record.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "record",

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnsupportedLogicalTests/UnsupportedLogicalTests.Verify.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnsupportedLogicalTests/UnsupportedLogicalTests.Verify.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
         public uint Size { get => (uint)Value.Length; }
     
-        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
-        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
+        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",


### PR DESCRIPTION
`s_schema` is more aligned with dotnet runtime and also matches the `s_protocol`. Also no need for it to be public.

Fix README links to specify the full url so that it doesn't show as broken links in nuget / details (hopefully).