### PR TITLE
Implement ISpecificRecord explicitly

### DIFF
--- a/src/AvroSourceGenerator/Templates/getput.sbncs
+++ b/src/AvroSourceGenerator/Templates/getput.sbncs
@@ -1,5 +1,5 @@
 {{~ $object = UseNullableReferenceTypes ? 'object?' : 'object' ~}}
-public {{~ $.override ? ' override ' : ' ' ~}} {{ $object}} Get(int fieldPos)
+{{~ $.override ? 'public override ' : 'public ' ~}} {{ $object}} Get(int fieldPos)
 {
     switch (fieldPos)
     {
@@ -11,7 +11,7 @@ public {{~ $.override ? ' override ' : ' ' ~}} {{ $object}} Get(int fieldPos)
 }
 
 {{~ $fieldValue = UseNullableReferenceTypes ? 'fieldValue!' : 'fieldValue' ~}}
-public {{~ $.override ? ' override ' : ' ' ~}} void Put(int fieldPos, {{ $object }} fieldValue)
+{{~ $.override ? 'public override ' : 'public ' ~}} void Put(int fieldPos, {{ $object }} fieldValue)
 {
     switch (fieldPos)
     {

--- a/src/AvroSourceGenerator/Templates/getput.sbncs
+++ b/src/AvroSourceGenerator/Templates/getput.sbncs
@@ -11,23 +11,17 @@ public {{~ $.override ? ' override ' : ' ' ~}} {{ $object}} Get(int fieldPos)
 }
 
 {{~ $fieldValue = UseNullableReferenceTypes ? 'fieldValue!' : 'fieldValue' ~}}
-{{~ if !UseInitOnlyProperties ~}}
 public {{~ $.override ? ' override ' : ' ' ~}} void Put(int fieldPos, {{ $object }} fieldValue)
 {
     switch (fieldPos)
     {
+        {{~ if !UseInitOnlyProperties ~}}
         {{~ for field in $.schema.Fields ~}}
         {{~ $expr = !field.IsNullable ? $"({ field.Type }){ $fieldValue }" : $"{ $fieldValue } is null ? null : ({ field.UnderlyingType }){ $fieldValue }" ~}}
         case {{ for.index }}: this.{{ field.Name }} = {{ $expr }}; break;
         {{~ end ~}}
         default: throw new global::Avro.AvroRuntimeException($"Bad index {fieldPos} in Put()");
-    }
-}
-{{~ else if UseUnsafeAccessors ~}}
-public {{~ $.override ? ' override ' : ' ' ~}} void Put(int fieldPos, {{ $object }} fieldValue)
-{
-    switch (fieldPos)
-    {
+        {{~ else if UseUnsafeAccessors ~}}
         {{~ for field in $.schema.Fields ~}}
         {{~ $expr = !field.IsNullable ? $"({ field.Type }){ $fieldValue }" : $"{ $fieldValue } is null ? null : ({ field.UnderlyingType }){ $fieldValue }" ~}}
         case {{ for.index }}:
@@ -37,20 +31,16 @@ public {{~ $.override ? ' override ' : ' ' ~}} void Put(int fieldPos, {{ $object
         {{~ end ~}}
         default:
             throw new global::Avro.AvroRuntimeException($"Bad index {fieldPos} in Put()");
-    }
-}
-{{~ else ~}}
-public {{~ $.override ? ' override ' : ' ' ~}} void Put(int fieldPos, {{ $object }} fieldValue)
-{
-    switch (fieldPos)
-    {
+        {{~ else ~}}
         {{~ for field in $.schema.Fields ~}}
         {{~ $expr = !field.IsNullable ? $"({ field.Type }){ $fieldValue }" : $"{ $fieldValue } is null ? null : ({ field.UnderlyingType }){ $fieldValue }" ~}}
         case {{ for.index }}: {{ $.schema.CSharpName.Name }}Reflection.Set_{{ field.Name }}(this, {{ $expr }}); break;
         {{~ end ~}}
         default: throw new global::Avro.AvroRuntimeException($"Bad index {fieldPos} in Put()");
+        {{~ end ~}}
     }
 }
+{{~ if UseInitOnlyProperties && !UseUnsafeAccessors ~}}
 
 private static class {{ $.schema.CSharpName.Name }}Reflection
 {

--- a/src/AvroSourceGenerator/Templates/getput.sbncs
+++ b/src/AvroSourceGenerator/Templates/getput.sbncs
@@ -1,5 +1,5 @@
 {{~ $object = UseNullableReferenceTypes ? 'object?' : 'object' ~}}
-{{~ $.override ? 'public override ' : 'public ' ~}} {{ $object}} Get(int fieldPos)
+{{~ $.override ? $"public override {$object} Get" : $"{$object} global::Avro.Specific.ISpecificRecord.Get" ~}}(int fieldPos)
 {
     switch (fieldPos)
     {
@@ -11,7 +11,7 @@
 }
 
 {{~ $fieldValue = UseNullableReferenceTypes ? 'fieldValue!' : 'fieldValue' ~}}
-{{~ $.override ? 'public override ' : 'public ' ~}} void Put(int fieldPos, {{ $object }} fieldValue)
+{{~ $.override ? 'public override void Put' : 'void global::Avro.Specific.ISpecificRecord.Put' ~}}(int fieldPos, {{ $object }} fieldValue)
 {
     switch (fieldPos)
     {

--- a/src/AvroSourceGenerator/Templates/record.sbncs
+++ b/src/AvroSourceGenerator/Templates/record.sbncs
@@ -4,7 +4,7 @@
     {{ include 'field' field: field }}
     {{~ end ~}}
 
-    public global::Avro.Schema Schema { get => {{ $.schema.CSharpName.Name }}.s_schema; }
+    global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => {{ $.schema.CSharpName.Name }}.s_schema; }
     private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
     {{ $.schema | json }});
 

--- a/tests/AvroSourceGenerator.Tests/AliasesTests.Verify_aliases=Alias1,Alias2_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AliasesTests.Verify_aliases=Alias1,Alias2_schemaType=record.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/AliasesTests.Verify_aliases=Alias1,Alias2_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AliasesTests.Verify_aliases=Alias1,Alias2_schemaType=record.verified.txt
@@ -23,7 +23,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -31,7 +31,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/AliasesTests.Verify_aliases=[]_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AliasesTests.Verify_aliases=[]_schemaType=record.verified.txt
@@ -7,7 +7,7 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/AliasesTests.Verify_aliases=[]_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AliasesTests.Verify_aliases=[]_schemaType=record.verified.txt
@@ -18,7 +18,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -26,7 +26,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/AliasesTests.Verify_aliases=null_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AliasesTests.Verify_aliases=null_schemaType=record.verified.txt
@@ -7,7 +7,7 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/AliasesTests.Verify_aliases=null_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AliasesTests.Verify_aliases=null_schemaType=record.verified.txt
@@ -18,7 +18,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -26,7 +26,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/AttributeAccessModifierTests.Verify_accessModifier=_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeAccessModifierTests.Verify_accessModifier=_schemaType=record.verified.txt
@@ -7,7 +7,7 @@ namespace SchemaNamespace
     internal partial class Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/AttributeAccessModifierTests.Verify_accessModifier=_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeAccessModifierTests.Verify_accessModifier=_schemaType=record.verified.txt
@@ -18,7 +18,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -26,7 +26,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/AttributeAccessModifierTests.Verify_accessModifier=file_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeAccessModifierTests.Verify_accessModifier=file_schemaType=record.verified.txt
@@ -18,7 +18,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -26,7 +26,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/AttributeAccessModifierTests.Verify_accessModifier=file_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeAccessModifierTests.Verify_accessModifier=file_schemaType=record.verified.txt
@@ -7,7 +7,7 @@ namespace SchemaNamespace
     file partial class Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/AttributeAccessModifierTests.Verify_accessModifier=internal_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeAccessModifierTests.Verify_accessModifier=internal_schemaType=record.verified.txt
@@ -7,7 +7,7 @@ namespace SchemaNamespace
     internal partial class Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/AttributeAccessModifierTests.Verify_accessModifier=internal_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeAccessModifierTests.Verify_accessModifier=internal_schemaType=record.verified.txt
@@ -18,7 +18,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -26,7 +26,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/AttributeAccessModifierTests.Verify_accessModifier=public_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeAccessModifierTests.Verify_accessModifier=public_schemaType=record.verified.txt
@@ -18,7 +18,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -26,7 +26,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/AttributeAccessModifierTests.Verify_accessModifier=public_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeAccessModifierTests.Verify_accessModifier=public_schemaType=record.verified.txt
@@ -7,7 +7,7 @@ namespace SchemaNamespace
     public partial class Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/AttributeFullNameTests.Verify.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeFullNameTests.Verify.verified.txt
@@ -18,7 +18,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -26,7 +26,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/AttributeFullNameTests.Verify.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeFullNameTests.Verify.verified.txt
@@ -7,7 +7,7 @@ namespace SchemaNamespace
     internal partial class Example : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Example.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Example.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=record.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public string Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     

--- a/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=record.verified.txt
@@ -12,7 +12,7 @@ namespace SchemaNamespace
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -21,7 +21,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=record.verified.txt
@@ -24,7 +24,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -33,7 +33,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=record.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public required string Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=record.verified.txt
@@ -24,7 +24,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -33,7 +33,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=record.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public required string Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=record.verified.txt
@@ -24,7 +24,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -33,7 +33,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=record.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public required string Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=record.verified.txt
@@ -11,7 +11,7 @@ namespace SchemaNamespace
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     
-        public object Get(int fieldPos)
+        object global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -20,7 +20,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=record.verified.txt
@@ -7,7 +7,7 @@ namespace SchemaNamespace
     {
         public string Field { get; set; }
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     

--- a/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=record.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public string Field { get; set; }
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     

--- a/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=record.verified.txt
@@ -12,7 +12,7 @@ namespace SchemaNamespace
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -21,7 +21,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=record.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public string Field { get; set; }
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     

--- a/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=record.verified.txt
@@ -12,7 +12,7 @@ namespace SchemaNamespace
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -21,7 +21,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/AttributeRecordDeclarationTests.Verify_recordDeclaration=class_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeRecordDeclarationTests.Verify_recordDeclaration=class_schemaType=record.verified.txt
@@ -18,7 +18,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -26,7 +26,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/AttributeRecordDeclarationTests.Verify_recordDeclaration=class_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeRecordDeclarationTests.Verify_recordDeclaration=class_schemaType=record.verified.txt
@@ -7,7 +7,7 @@ namespace SchemaNamespace
     public partial class Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/AttributeRecordDeclarationTests.Verify_recordDeclaration=record_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeRecordDeclarationTests.Verify_recordDeclaration=record_schemaType=record.verified.txt
@@ -7,7 +7,7 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/AttributeRecordDeclarationTests.Verify_recordDeclaration=record_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/AttributeRecordDeclarationTests.Verify_recordDeclaration=record_schemaType=record.verified.txt
@@ -18,7 +18,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -26,7 +26,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=record.verified.txt
@@ -18,7 +18,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -26,7 +26,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=record.verified.txt
@@ -7,7 +7,7 @@ namespace SchemaNamespace
     internal partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=record.verified.txt
@@ -7,7 +7,7 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=record.verified.txt
@@ -18,7 +18,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -26,7 +26,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=record.verified.txt
@@ -7,7 +7,7 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=record.verified.txt
@@ -18,7 +18,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -26,7 +26,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=record.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public string Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     

--- a/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=record.verified.txt
@@ -12,7 +12,7 @@ namespace SchemaNamespace
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -21,7 +21,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=record.verified.txt
@@ -24,7 +24,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -33,7 +33,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=record.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public required string Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=record.verified.txt
@@ -24,7 +24,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -33,7 +33,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=record.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public required string Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=record.verified.txt
@@ -24,7 +24,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -33,7 +33,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=record.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public required string Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=record.verified.txt
@@ -11,7 +11,7 @@ namespace SchemaNamespace
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     
-        public object Get(int fieldPos)
+        object global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -20,7 +20,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=record.verified.txt
@@ -7,7 +7,7 @@ namespace SchemaNamespace
     {
         public string Field { get; set; }
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     

--- a/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=record.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public string Field { get; set; }
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     

--- a/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=record.verified.txt
@@ -12,7 +12,7 @@ namespace SchemaNamespace
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -21,7 +21,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=record.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public string Field { get; set; }
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     

--- a/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=record.verified.txt
@@ -12,7 +12,7 @@ namespace SchemaNamespace
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}]}");
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -21,7 +21,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=record.verified.txt
@@ -24,7 +24,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -33,7 +33,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=record.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public required string Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/CsprojRecordDeclarationTests.Verify_recordDeclaration=class_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojRecordDeclarationTests.Verify_recordDeclaration=class_schemaType=record.verified.txt
@@ -18,7 +18,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -26,7 +26,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/CsprojRecordDeclarationTests.Verify_recordDeclaration=class_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojRecordDeclarationTests.Verify_recordDeclaration=class_schemaType=record.verified.txt
@@ -7,7 +7,7 @@ namespace SchemaNamespace
     public partial class Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/CsprojRecordDeclarationTests.Verify_recordDeclaration=invalid_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojRecordDeclarationTests.Verify_recordDeclaration=invalid_schemaType=record.verified.txt
@@ -7,7 +7,7 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/CsprojRecordDeclarationTests.Verify_recordDeclaration=invalid_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojRecordDeclarationTests.Verify_recordDeclaration=invalid_schemaType=record.verified.txt
@@ -18,7 +18,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -26,7 +26,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/CsprojRecordDeclarationTests.Verify_recordDeclaration=record_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojRecordDeclarationTests.Verify_recordDeclaration=record_schemaType=record.verified.txt
@@ -7,7 +7,7 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/CsprojRecordDeclarationTests.Verify_recordDeclaration=record_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/CsprojRecordDeclarationTests.Verify_recordDeclaration=record_schemaType=record.verified.txt
@@ -18,7 +18,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -26,7 +26,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/DocumentationTests.Verify_doc=Multi-line-comment_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/DocumentationTests.Verify_doc=Multi-line-comment_schemaType=record.verified.txt
@@ -24,7 +24,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -32,7 +32,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/DocumentationTests.Verify_doc=Multi-line-comment_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/DocumentationTests.Verify_doc=Multi-line-comment_schemaType=record.verified.txt
@@ -12,7 +12,7 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/DocumentationTests.Verify_doc=Single line comment_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/DocumentationTests.Verify_doc=Single line comment_schemaType=record.verified.txt
@@ -22,7 +22,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -30,7 +30,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/DocumentationTests.Verify_doc=Single line comment_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/DocumentationTests.Verify_doc=Single line comment_schemaType=record.verified.txt
@@ -10,7 +10,7 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/DocumentationTests.Verify_doc=_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/DocumentationTests.Verify_doc=_schemaType=record.verified.txt
@@ -7,7 +7,7 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/DocumentationTests.Verify_doc=_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/DocumentationTests.Verify_doc=_schemaType=record.verified.txt
@@ -18,7 +18,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -26,7 +26,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/DocumentationTests.Verify_doc=null_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/DocumentationTests.Verify_doc=null_schemaType=record.verified.txt
@@ -7,7 +7,7 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/DocumentationTests.Verify_doc=null_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/DocumentationTests.Verify_doc=null_schemaType=record.verified.txt
@@ -18,7 +18,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -26,7 +26,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=boolean_defaultValue=true.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=boolean_defaultValue=true.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public bool Field { get; init; } = true;
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=boolean_defaultValue=true.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=boolean_defaultValue=true.verified.txt
@@ -25,7 +25,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -34,7 +34,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=bytes_defaultValue=-NDI=-.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=bytes_defaultValue=-NDI=-.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public byte[] Field { get; init; } = [0x34, 0x32];
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=bytes_defaultValue=-NDI=-.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=bytes_defaultValue=-NDI=-.verified.txt
@@ -25,7 +25,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -34,7 +34,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=double_defaultValue=42.0.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=double_defaultValue=42.0.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public double Field { get; init; } = 42.0;
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=double_defaultValue=42.0.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=double_defaultValue=42.0.verified.txt
@@ -25,7 +25,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -34,7 +34,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=enum-A,B,C-_defaultValue=-B-#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=enum-A,B,C-_defaultValue=-B-#01.verified.txt
@@ -34,7 +34,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -43,7 +43,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=enum-A,B,C-_defaultValue=-B-#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=enum-A,B,C-_defaultValue=-B-#01.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public global::SchemaNamespace.Enum Field { get; init; } = global::SchemaNamespace.Enum.B;
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=float_defaultValue=42.0.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=float_defaultValue=42.0.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public float Field { get; init; } = 42.0f;
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=float_defaultValue=42.0.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=float_defaultValue=42.0.verified.txt
@@ -25,7 +25,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -34,7 +34,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=int_defaultValue=42.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=int_defaultValue=42.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public int Field { get; init; } = 42;
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=int_defaultValue=42.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=int_defaultValue=42.verified.txt
@@ -25,7 +25,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -34,7 +34,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=long_defaultValue=42.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=long_defaultValue=42.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public long Field { get; init; } = 42;
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=long_defaultValue=42.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=long_defaultValue=42.verified.txt
@@ -25,7 +25,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -34,7 +34,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=null_defaultValue=null.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=null_defaultValue=null.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public required object Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=null_defaultValue=null.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=null_defaultValue=null.verified.txt
@@ -25,7 +25,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -34,7 +34,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=string_defaultValue=-FortyTwo-.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=string_defaultValue=-FortyTwo-.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public string Field { get; init; } = "FortyTwo";
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=string_defaultValue=-FortyTwo-.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldDefaultTests.Verify_schemaType=string_defaultValue=-FortyTwo-.verified.txt
@@ -25,7 +25,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -34,7 +34,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/FieldEnumTests.Verify_class=record#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldEnumTests.Verify_class=record#01.verified.txt
@@ -9,7 +9,7 @@ namespace SchemaNamespace
         public required global::SchemaNamespace.Enum Field { get; init; }
         public global::SchemaNamespace.Enum? NullableField { get; init; }
     
-        public global::Avro.Schema Schema { get => Class.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Class.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/FieldEnumTests.Verify_class=record#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldEnumTests.Verify_class=record#01.verified.txt
@@ -41,7 +41,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -51,7 +51,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/FieldMetadataPropertyTests.Verify_class=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldMetadataPropertyTests.Verify_class=record.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public string? Field { get; init; }
     
-        public global::Avro.Schema Schema { get => Class.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Class.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/FieldMetadataPropertyTests.Verify_class=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldMetadataPropertyTests.Verify_class=record.verified.txt
@@ -34,7 +34,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -43,7 +43,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=boolean.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=boolean.verified.txt
@@ -32,7 +32,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -42,7 +42,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=boolean.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=boolean.verified.txt
@@ -9,7 +9,7 @@ namespace SchemaNamespace
         public required bool Field { get; init; }
         public bool? NullableField { get; init; }
     
-        public global::Avro.Schema Schema { get => Class.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Class.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=bytes.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=bytes.verified.txt
@@ -9,7 +9,7 @@ namespace SchemaNamespace
         public required byte[] Field { get; init; }
         public byte[]? NullableField { get; init; }
     
-        public global::Avro.Schema Schema { get => Class.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Class.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=bytes.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=bytes.verified.txt
@@ -32,7 +32,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -42,7 +42,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=double.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=double.verified.txt
@@ -32,7 +32,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -42,7 +42,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=double.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=double.verified.txt
@@ -9,7 +9,7 @@ namespace SchemaNamespace
         public required double Field { get; init; }
         public double? NullableField { get; init; }
     
-        public global::Avro.Schema Schema { get => Class.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Class.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=float.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=float.verified.txt
@@ -32,7 +32,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -42,7 +42,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=float.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=float.verified.txt
@@ -9,7 +9,7 @@ namespace SchemaNamespace
         public required float Field { get; init; }
         public float? NullableField { get; init; }
     
-        public global::Avro.Schema Schema { get => Class.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Class.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=int.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=int.verified.txt
@@ -32,7 +32,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -42,7 +42,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=int.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=int.verified.txt
@@ -9,7 +9,7 @@ namespace SchemaNamespace
         public required int Field { get; init; }
         public int? NullableField { get; init; }
     
-        public global::Avro.Schema Schema { get => Class.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Class.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=long.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=long.verified.txt
@@ -32,7 +32,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -42,7 +42,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=long.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=long.verified.txt
@@ -9,7 +9,7 @@ namespace SchemaNamespace
         public required long Field { get; init; }
         public long? NullableField { get; init; }
     
-        public global::Avro.Schema Schema { get => Class.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Class.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=null.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=null.verified.txt
@@ -9,7 +9,7 @@ namespace SchemaNamespace
         public required object Field { get; init; }
         public object? NullableField { get; init; }
     
-        public global::Avro.Schema Schema { get => Class.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Class.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=null.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=null.verified.txt
@@ -32,7 +32,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -42,7 +42,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=string.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=string.verified.txt
@@ -9,7 +9,7 @@ namespace SchemaNamespace
         public required string Field { get; init; }
         public string? NullableField { get; init; }
     
-        public global::Avro.Schema Schema { get => Class.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Class.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=string.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldPrimitiveTests.Verify_class=record_field=string.verified.txt
@@ -32,7 +32,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -42,7 +42,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/FullNameTests.Verify#03.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FullNameTests.Verify#03.verified.txt
@@ -37,7 +37,7 @@ namespace a.full
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -46,7 +46,7 @@ namespace a.full
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/FullNameTests.Verify#03.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FullNameTests.Verify#03.verified.txt
@@ -11,7 +11,7 @@ namespace a.full
     {
         public required global::a.full.Understanding inheritNamespace { get; init; }
     
-        public global::Avro.Schema Schema { get => Name.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Name.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/FullNameTests.Verify#04.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FullNameTests.Verify#04.verified.txt
@@ -11,7 +11,7 @@
         public required global::@explicit.Simple explicitNamespace { get; init; }
         public required global::a.full.Name fullName { get; init; }
     
-        public global::Avro.Schema Schema { get => Example.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Example.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/FullNameTests.Verify#04.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FullNameTests.Verify#04.verified.txt
@@ -69,7 +69,7 @@
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -80,7 +80,7 @@
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Date.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Date.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public required global::System.DateTime DateField { get; init; }
     
-        public global::Avro.Schema Schema { get => Container.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Date.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Date.verified.txt
@@ -27,7 +27,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -36,7 +36,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Decimal_Bytes.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Decimal_Bytes.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public required global::Avro.AvroDecimal DecimalField { get; init; }
     
-        public global::Avro.Schema Schema { get => Container.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Decimal_Bytes.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Decimal_Bytes.verified.txt
@@ -29,7 +29,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -38,7 +38,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Decimal_Fixed#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Decimal_Fixed#01.verified.txt
@@ -32,7 +32,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -41,7 +41,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Decimal_Fixed#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Decimal_Fixed#01.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public required global::Avro.AvroDecimal DecimalField { get; init; }
     
-        public global::Avro.Schema Schema { get => Container.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Local_Timestamp_Microseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Local_Timestamp_Microseconds.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public required global::System.DateTime TimestampField { get; init; }
     
-        public global::Avro.Schema Schema { get => Container.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Local_Timestamp_Microseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Local_Timestamp_Microseconds.verified.txt
@@ -27,7 +27,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -36,7 +36,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Local_Timestamp_Milliseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Local_Timestamp_Milliseconds.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public required global::System.DateTime TimestampField { get; init; }
     
-        public global::Avro.Schema Schema { get => Container.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Local_Timestamp_Milliseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Local_Timestamp_Milliseconds.verified.txt
@@ -27,7 +27,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -36,7 +36,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Time_Microseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Time_Microseconds.verified.txt
@@ -27,7 +27,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -36,7 +36,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Time_Microseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Time_Microseconds.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public required global::System.TimeSpan TimeField { get; init; }
     
-        public global::Avro.Schema Schema { get => Container.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Time_Milliseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Time_Milliseconds.verified.txt
@@ -27,7 +27,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -36,7 +36,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Time_Milliseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Time_Milliseconds.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public required global::System.TimeSpan TimeField { get; init; }
     
-        public global::Avro.Schema Schema { get => Container.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Timestamp_Microseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Timestamp_Microseconds.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public required global::System.DateTime TimestampField { get; init; }
     
-        public global::Avro.Schema Schema { get => Container.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Timestamp_Microseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Timestamp_Microseconds.verified.txt
@@ -27,7 +27,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -36,7 +36,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Timestamp_Milliseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Timestamp_Milliseconds.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public required global::System.DateTime TimestampField { get; init; }
     
-        public global::Avro.Schema Schema { get => Container.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Timestamp_Milliseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Timestamp_Milliseconds.verified.txt
@@ -27,7 +27,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -36,7 +36,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Uuid_Fixed#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Uuid_Fixed#01.verified.txt
@@ -30,7 +30,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -39,7 +39,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Uuid_Fixed#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Uuid_Fixed#01.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public required global::System.Guid UuidField { get; init; }
     
-        public global::Avro.Schema Schema { get => Container.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Uuid_String.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Uuid_String.verified.txt
@@ -27,7 +27,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -36,7 +36,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Uuid_String.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/LogicalTests.Verify_Uuid_String.verified.txt
@@ -8,7 +8,7 @@ namespace SchemaNamespace
     {
         public required global::System.Guid UuidField { get; init; }
     
-        public global::Avro.Schema Schema { get => Container.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/MetadataPropertiesTests.Verify_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/MetadataPropertiesTests.Verify_schemaType=record.verified.txt
@@ -7,7 +7,7 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/MetadataPropertiesTests.Verify_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/MetadataPropertiesTests.Verify_schemaType=record.verified.txt
@@ -22,7 +22,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -30,7 +30,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/NameTests.Verify_name=PascalCase_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/NameTests.Verify_name=PascalCase_schemaType=record.verified.txt
@@ -18,7 +18,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -26,7 +26,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/NameTests.Verify_name=PascalCase_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/NameTests.Verify_name=PascalCase_schemaType=record.verified.txt
@@ -7,7 +7,7 @@ namespace SchemaNamespace
     public partial record PascalCase : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => PascalCase.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => PascalCase.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/NameTests.Verify_name=object_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/NameTests.Verify_name=object_schemaType=record.verified.txt
@@ -18,7 +18,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -26,7 +26,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/NameTests.Verify_name=object_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/NameTests.Verify_name=object_schemaType=record.verified.txt
@@ -7,7 +7,7 @@ namespace SchemaNamespace
     public partial record @object : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => @object.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => @object.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/NameTests.Verify_name=snake_case_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/NameTests.Verify_name=snake_case_schemaType=record.verified.txt
@@ -18,7 +18,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -26,7 +26,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/NameTests.Verify_name=snake_case_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/NameTests.Verify_name=snake_case_schemaType=record.verified.txt
@@ -7,7 +7,7 @@ namespace SchemaNamespace
     public partial record snake_case : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => snake_case.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => snake_case.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/NamespaceTests.Verify_namespace=PascalCase.snake_case.object_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/NamespaceTests.Verify_namespace=PascalCase.snake_case.object_schemaType=record.verified.txt
@@ -18,7 +18,7 @@ namespace PascalCase.snake_case.@object
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -26,7 +26,7 @@ namespace PascalCase.snake_case.@object
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/NamespaceTests.Verify_namespace=PascalCase.snake_case.object_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/NamespaceTests.Verify_namespace=PascalCase.snake_case.object_schemaType=record.verified.txt
@@ -7,7 +7,7 @@ namespace PascalCase.snake_case.@object
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/NamespaceTests.Verify_namespace=_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/NamespaceTests.Verify_namespace=_schemaType=record.verified.txt
@@ -15,7 +15,7 @@
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -23,7 +23,7 @@
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/NamespaceTests.Verify_namespace=_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/NamespaceTests.Verify_namespace=_schemaType=record.verified.txt
@@ -5,7 +5,7 @@
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/NamespaceTests.Verify_namespace=null_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/NamespaceTests.Verify_namespace=null_schemaType=record.verified.txt
@@ -15,7 +15,7 @@
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -23,7 +23,7 @@
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/NamespaceTests.Verify_namespace=null_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/NamespaceTests.Verify_namespace=null_schemaType=record.verified.txt
@@ -5,7 +5,7 @@
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/SchemaReferenceTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/SchemaReferenceTests.Verify#00.verified.txt
@@ -18,7 +18,7 @@ namespace This.Is.A.Full
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -26,7 +26,7 @@ namespace This.Is.A.Full
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/SchemaReferenceTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/SchemaReferenceTests.Verify#00.verified.txt
@@ -7,7 +7,7 @@ namespace This.Is.A.Full
     public partial record Name : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Name.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Name.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/SchemaReferenceTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/SchemaReferenceTests.Verify#01.verified.txt
@@ -11,7 +11,7 @@ namespace This.Is.A.Full
         /// </summary>
         public required global::This.Is.A.Full.Name Field4 { get; init; }
     
-        public global::Avro.Schema Schema { get => OtherName.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => OtherName.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/SchemaReferenceTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/SchemaReferenceTests.Verify#01.verified.txt
@@ -33,7 +33,7 @@ namespace This.Is.A.Full
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -42,7 +42,7 @@ namespace This.Is.A.Full
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/SchemaReferenceTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/SchemaReferenceTests.Verify#02.verified.txt
@@ -11,7 +11,7 @@
         public required global::This.Is.A.Full.Name Field2 { get; init; }
         public required global::This.Is.A.Full.OtherName Field3 { get; init; }
     
-        public global::Avro.Schema Schema { get => Wrapper.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Wrapper.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/SchemaReferenceTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/SchemaReferenceTests.Verify#02.verified.txt
@@ -51,7 +51,7 @@
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -62,7 +62,7 @@
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/SelfContainedSchemaTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/SelfContainedSchemaTests.Verify#00.verified.txt
@@ -24,7 +24,7 @@ namespace Namespace1
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -33,7 +33,7 @@ namespace Namespace1
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/SelfContainedSchemaTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/SelfContainedSchemaTests.Verify#00.verified.txt
@@ -8,7 +8,7 @@ namespace Namespace1
     {
         public required string field1 { get; init; }
     
-        public global::Avro.Schema Schema { get => Record1.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record1.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/SelfContainedSchemaTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/SelfContainedSchemaTests.Verify#01.verified.txt
@@ -11,7 +11,7 @@ namespace Namespace1
     {
         public required global::Namespace1.Record1 field1 { get; init; }
     
-        public global::Avro.Schema Schema { get => Record2.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record2.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/SelfContainedSchemaTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/SelfContainedSchemaTests.Verify#01.verified.txt
@@ -38,7 +38,7 @@ namespace Namespace1
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -47,7 +47,7 @@ namespace Namespace1
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionAbstractBaseTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionAbstractBaseTests.Verify#00.verified.txt
@@ -34,7 +34,7 @@ namespace com.example.notifications
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -45,7 +45,7 @@ namespace com.example.notifications
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionAbstractBaseTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionAbstractBaseTests.Verify#00.verified.txt
@@ -10,7 +10,7 @@ namespace com.example.notifications
         public required string body { get; init; }
         public required string recipientEmail { get; init; }
     
-        public global::Avro.Schema Schema { get => EmailContent.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => EmailContent.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionAbstractBaseTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionAbstractBaseTests.Verify#01.verified.txt
@@ -9,7 +9,7 @@ namespace com.example.notifications
         public required string message { get; init; }
         public required string phoneNumber { get; init; }
     
-        public global::Avro.Schema Schema { get => SmsContent.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => SmsContent.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionAbstractBaseTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionAbstractBaseTests.Verify#01.verified.txt
@@ -29,7 +29,7 @@ namespace com.example.notifications
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -39,7 +39,7 @@ namespace com.example.notifications
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionAbstractBaseTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionAbstractBaseTests.Verify#02.verified.txt
@@ -10,7 +10,7 @@ namespace com.example.notifications
         public required string message { get; init; }
         public required string deviceToken { get; init; }
     
-        public global::Avro.Schema Schema { get => PushContent.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => PushContent.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionAbstractBaseTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionAbstractBaseTests.Verify#02.verified.txt
@@ -34,7 +34,7 @@ namespace com.example.notifications
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -45,7 +45,7 @@ namespace com.example.notifications
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionAbstractBaseTests.Verify#04.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionAbstractBaseTests.Verify#04.verified.txt
@@ -90,7 +90,7 @@ namespace com.example.notifications
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -99,7 +99,7 @@ namespace com.example.notifications
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionAbstractBaseTests.Verify#04.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionAbstractBaseTests.Verify#04.verified.txt
@@ -19,7 +19,7 @@ namespace com.example.notifications
         /// </remarks>
         public required global::com.example.notifications.NotificationContentVariant content { get; init; }
     
-        public global::Avro.Schema Schema { get => Notification.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Notification.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionAbstractNullableBaseTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionAbstractNullableBaseTests.Verify#00.verified.txt
@@ -34,7 +34,7 @@ namespace com.example.notifications
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -45,7 +45,7 @@ namespace com.example.notifications
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionAbstractNullableBaseTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionAbstractNullableBaseTests.Verify#00.verified.txt
@@ -10,7 +10,7 @@ namespace com.example.notifications
         public required string body { get; init; }
         public required string recipientEmail { get; init; }
     
-        public global::Avro.Schema Schema { get => EmailContent.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => EmailContent.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionAbstractNullableBaseTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionAbstractNullableBaseTests.Verify#01.verified.txt
@@ -9,7 +9,7 @@ namespace com.example.notifications
         public required string message { get; init; }
         public required string phoneNumber { get; init; }
     
-        public global::Avro.Schema Schema { get => SmsContent.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => SmsContent.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionAbstractNullableBaseTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionAbstractNullableBaseTests.Verify#01.verified.txt
@@ -29,7 +29,7 @@ namespace com.example.notifications
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -39,7 +39,7 @@ namespace com.example.notifications
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionAbstractNullableBaseTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionAbstractNullableBaseTests.Verify#02.verified.txt
@@ -10,7 +10,7 @@ namespace com.example.notifications
         public required string message { get; init; }
         public required string deviceToken { get; init; }
     
-        public global::Avro.Schema Schema { get => PushContent.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => PushContent.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionAbstractNullableBaseTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionAbstractNullableBaseTests.Verify#02.verified.txt
@@ -34,7 +34,7 @@ namespace com.example.notifications
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -45,7 +45,7 @@ namespace com.example.notifications
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionAbstractNullableBaseTests.Verify#04.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionAbstractNullableBaseTests.Verify#04.verified.txt
@@ -20,7 +20,7 @@ namespace com.example.notifications
         /// </remarks>
         public global::com.example.notifications.NotificationContentVariant? content { get; init; }
     
-        public global::Avro.Schema Schema { get => Notification.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Notification.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionAbstractNullableBaseTests.Verify#04.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionAbstractNullableBaseTests.Verify#04.verified.txt
@@ -93,7 +93,7 @@ namespace com.example.notifications
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -102,7 +102,7 @@ namespace com.example.notifications
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionObjectBaseTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionObjectBaseTests.Verify#00.verified.txt
@@ -34,7 +34,7 @@ namespace com.example.notifications
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -45,7 +45,7 @@ namespace com.example.notifications
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionObjectBaseTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionObjectBaseTests.Verify#00.verified.txt
@@ -10,7 +10,7 @@ namespace com.example.notifications
         public required string body { get; init; }
         public required string recipientEmail { get; init; }
     
-        public global::Avro.Schema Schema { get => EmailContent.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => EmailContent.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionObjectBaseTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionObjectBaseTests.Verify#01.verified.txt
@@ -9,7 +9,7 @@ namespace com.example.notifications
         public required string message { get; init; }
         public required string phoneNumber { get; init; }
     
-        public global::Avro.Schema Schema { get => SmsContent.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => SmsContent.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionObjectBaseTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionObjectBaseTests.Verify#01.verified.txt
@@ -29,7 +29,7 @@ namespace com.example.notifications
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -39,7 +39,7 @@ namespace com.example.notifications
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionObjectBaseTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionObjectBaseTests.Verify#02.verified.txt
@@ -10,7 +10,7 @@ namespace com.example.notifications
         public required string message { get; init; }
         public required string deviceToken { get; init; }
     
-        public global::Avro.Schema Schema { get => PushContent.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => PushContent.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionObjectBaseTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionObjectBaseTests.Verify#02.verified.txt
@@ -34,7 +34,7 @@ namespace com.example.notifications
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -45,7 +45,7 @@ namespace com.example.notifications
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionObjectBaseTests.Verify#03.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionObjectBaseTests.Verify#03.verified.txt
@@ -11,7 +11,7 @@ namespace com.example.notifications
         /// </summary>
         public required object content { get; init; }
     
-        public global::Avro.Schema Schema { get => Notification.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Notification.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionObjectBaseTests.Verify#03.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionObjectBaseTests.Verify#03.verified.txt
@@ -83,7 +83,7 @@ namespace com.example.notifications
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -92,7 +92,7 @@ namespace com.example.notifications
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionObjectNullableBaseTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionObjectNullableBaseTests.Verify#00.verified.txt
@@ -34,7 +34,7 @@ namespace com.example.notifications
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -45,7 +45,7 @@ namespace com.example.notifications
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionObjectNullableBaseTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionObjectNullableBaseTests.Verify#00.verified.txt
@@ -10,7 +10,7 @@ namespace com.example.notifications
         public required string body { get; init; }
         public required string recipientEmail { get; init; }
     
-        public global::Avro.Schema Schema { get => EmailContent.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => EmailContent.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionObjectNullableBaseTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionObjectNullableBaseTests.Verify#01.verified.txt
@@ -9,7 +9,7 @@ namespace com.example.notifications
         public required string message { get; init; }
         public required string phoneNumber { get; init; }
     
-        public global::Avro.Schema Schema { get => SmsContent.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => SmsContent.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionObjectNullableBaseTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionObjectNullableBaseTests.Verify#01.verified.txt
@@ -29,7 +29,7 @@ namespace com.example.notifications
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -39,7 +39,7 @@ namespace com.example.notifications
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionObjectNullableBaseTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionObjectNullableBaseTests.Verify#02.verified.txt
@@ -10,7 +10,7 @@ namespace com.example.notifications
         public required string message { get; init; }
         public required string deviceToken { get; init; }
     
-        public global::Avro.Schema Schema { get => PushContent.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => PushContent.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionObjectNullableBaseTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionObjectNullableBaseTests.Verify#02.verified.txt
@@ -34,7 +34,7 @@ namespace com.example.notifications
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -45,7 +45,7 @@ namespace com.example.notifications
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionObjectNullableBaseTests.Verify#03.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionObjectNullableBaseTests.Verify#03.verified.txt
@@ -85,7 +85,7 @@ namespace com.example.notifications
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -94,7 +94,7 @@ namespace com.example.notifications
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionObjectNullableBaseTests.Verify#03.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionObjectNullableBaseTests.Verify#03.verified.txt
@@ -11,7 +11,7 @@ namespace com.example.notifications
         /// </summary>
         public object? content { get; init; }
     
-        public global::Avro.Schema Schema { get => Notification.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Notification.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionRootAbstractTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionRootAbstractTests.Verify#00.verified.txt
@@ -8,7 +8,7 @@
         public required string body { get; init; }
         public required string recipientEmail { get; init; }
     
-        public global::Avro.Schema Schema { get => EmailContent.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => EmailContent.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionRootAbstractTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionRootAbstractTests.Verify#00.verified.txt
@@ -31,7 +31,7 @@
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -42,7 +42,7 @@
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionRootAbstractTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionRootAbstractTests.Verify#01.verified.txt
@@ -26,7 +26,7 @@
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -36,7 +36,7 @@
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionRootAbstractTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionRootAbstractTests.Verify#01.verified.txt
@@ -7,7 +7,7 @@
         public required string message { get; init; }
         public required string phoneNumber { get; init; }
     
-        public global::Avro.Schema Schema { get => SmsContent.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => SmsContent.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionRootAbstractTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionRootAbstractTests.Verify#02.verified.txt
@@ -31,7 +31,7 @@
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -42,7 +42,7 @@
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionRootAbstractTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionRootAbstractTests.Verify#02.verified.txt
@@ -8,7 +8,7 @@
         public required string message { get; init; }
         public required string deviceToken { get; init; }
     
-        public global::Avro.Schema Schema { get => PushContent.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => PushContent.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionRootObjectTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionRootObjectTests.Verify#01.verified.txt
@@ -8,7 +8,7 @@
         public required string body { get; init; }
         public required string recipientEmail { get; init; }
     
-        public global::Avro.Schema Schema { get => EmailContent.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => EmailContent.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionRootObjectTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionRootObjectTests.Verify#01.verified.txt
@@ -31,7 +31,7 @@
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -42,7 +42,7 @@
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionRootObjectTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionRootObjectTests.Verify#02.verified.txt
@@ -26,7 +26,7 @@
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -36,7 +36,7 @@
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionRootObjectTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionRootObjectTests.Verify#02.verified.txt
@@ -7,7 +7,7 @@
         public required string message { get; init; }
         public required string phoneNumber { get; init; }
     
-        public global::Avro.Schema Schema { get => SmsContent.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => SmsContent.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionRootObjectTests.Verify#03.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionRootObjectTests.Verify#03.verified.txt
@@ -31,7 +31,7 @@
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -42,7 +42,7 @@
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionRootObjectTests.Verify#03.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionRootObjectTests.Verify#03.verified.txt
@@ -8,7 +8,7 @@
         public required string message { get; init; }
         public required string deviceToken { get; init; }
     
-        public global::Avro.Schema Schema { get => PushContent.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => PushContent.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#00.verified.txt
@@ -30,7 +30,7 @@ namespace com.example.user
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -40,7 +40,7 @@ namespace com.example.user
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#00.verified.txt
@@ -9,7 +9,7 @@ namespace com.example.user
         public required string language { get; init; }
         public bool darkMode { get; init; } = false;
     
-        public global::Avro.Schema Schema { get => Preferences.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Preferences.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#01.verified.txt
@@ -10,7 +10,7 @@ namespace com.example.user
         public required string city { get; init; }
         public required string postalCode { get; init; }
     
-        public global::Avro.Schema Schema { get => Address.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Address.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#01.verified.txt
@@ -34,7 +34,7 @@ namespace com.example.user
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -45,7 +45,7 @@ namespace com.example.user
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#02.verified.txt
@@ -9,7 +9,7 @@ namespace com.example.user
         public required string createdAt { get; init; }
         public string? lastLogin { get; init; }
     
-        public global::Avro.Schema Schema { get => ProfileMetadata.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => ProfileMetadata.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#02.verified.txt
@@ -33,7 +33,7 @@ namespace com.example.user
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -43,7 +43,7 @@ namespace com.example.user
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#03.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#03.verified.txt
@@ -24,7 +24,7 @@ namespace com.example.user
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -33,7 +33,7 @@ namespace com.example.user
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#03.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#03.verified.txt
@@ -8,7 +8,7 @@ namespace com.example.user
     {
         public required string email { get; init; }
     
-        public global::Avro.Schema Schema { get => EmailContact.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => EmailContact.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#04.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#04.verified.txt
@@ -24,7 +24,7 @@ namespace com.example.user
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -33,7 +33,7 @@ namespace com.example.user
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#04.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#04.verified.txt
@@ -8,7 +8,7 @@ namespace com.example.user
     {
         public required string phoneNumber { get; init; }
     
-        public global::Avro.Schema Schema { get => PhoneContact.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => PhoneContact.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#06.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#06.verified.txt
@@ -169,7 +169,7 @@ namespace com.example.user
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -182,7 +182,7 @@ namespace com.example.user
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#06.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#06.verified.txt
@@ -38,7 +38,7 @@ namespace com.example.user
         /// </remarks>
         public global::com.example.user.UserProfileContactVariant? contact { get; init; }
     
-        public global::Avro.Schema Schema { get => UserProfile.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => UserProfile.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnnamedRootSchemasTests.Verify_schemaType=[null, record].verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnnamedRootSchemasTests.Verify_schemaType=[null, record].verified.txt
@@ -7,7 +7,7 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnnamedRootSchemasTests.Verify_schemaType=[null, record].verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnnamedRootSchemasTests.Verify_schemaType=[null, record].verified.txt
@@ -18,7 +18,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -26,7 +26,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnnamedRootSchemasTests.Verify_schemaType=array-record-.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnnamedRootSchemasTests.Verify_schemaType=array-record-.verified.txt
@@ -7,7 +7,7 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnnamedRootSchemasTests.Verify_schemaType=array-record-.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnnamedRootSchemasTests.Verify_schemaType=array-record-.verified.txt
@@ -18,7 +18,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -26,7 +26,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {

--- a/tests/AvroSourceGenerator.Tests/UnnamedRootSchemasTests.Verify_schemaType=map-record-.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnnamedRootSchemasTests.Verify_schemaType=map-record-.verified.txt
@@ -7,7 +7,7 @@ namespace SchemaNamespace
     public partial record Record : global::Avro.Specific.ISpecificRecord
     {
     
-        public global::Avro.Schema Schema { get => Record.s_schema; }
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
         private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
         """
         {

--- a/tests/AvroSourceGenerator.Tests/UnnamedRootSchemasTests.Verify_schemaType=map-record-.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnnamedRootSchemasTests.Verify_schemaType=map-record-.verified.txt
@@ -18,7 +18,7 @@ namespace SchemaNamespace
         }
         """);
     
-        public object? Get(int fieldPos)
+        object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
         {
             switch (fieldPos)
             {
@@ -26,7 +26,7 @@ namespace SchemaNamespace
             }
         }
         
-        public void Put(int fieldPos, object? fieldValue)
+        void global::Avro.Specific.ISpecificRecord.Put(int fieldPos, object? fieldValue)
         {
             switch (fieldPos)
             {


### PR DESCRIPTION
Implement ISpecificRecord explicitly instead of implicitly.

This makes Record instances prettier to print and serialize.