### PR TITLE
Use concrete types for collection schemas

### DIFF
--- a/src/AvroSourceGenerator/Schemas/ArraySchema.cs
+++ b/src/AvroSourceGenerator/Schemas/ArraySchema.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 namespace AvroSourceGenerator.Schemas;
 
 internal sealed record class ArraySchema(AvroSchema ItemSchema, ImmutableSortedDictionary<string, JsonElement> Properties)
-    : AvroSchema(SchemaType.Array, new CSharpName($"IList<{ItemSchema}>", "System.Collections.Generic"), new SchemaName("array"))
+    : AvroSchema(SchemaType.Array, new CSharpName($"List<{ItemSchema}>", "System.Collections.Generic"), new SchemaName("array"))
 {
     public override void WriteTo(Utf8JsonWriter writer, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {

--- a/src/AvroSourceGenerator/Schemas/MapSchema.cs
+++ b/src/AvroSourceGenerator/Schemas/MapSchema.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 namespace AvroSourceGenerator.Schemas;
 
 internal sealed record class MapSchema(AvroSchema ValueSchema, ImmutableSortedDictionary<string, JsonElement> Properties)
-    : AvroSchema(SchemaType.Map, new CSharpName($"IDictionary<string, {ValueSchema}>", "System.Collections.Generic"), new SchemaName("map"))
+    : AvroSchema(SchemaType.Map, new CSharpName($"Dictionary<string, {ValueSchema}>", "System.Collections.Generic"), new SchemaName("map"))
 {
     public override void WriteTo(Utf8JsonWriter writer, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {

--- a/tests/AvroSourceGenerator.Tests/FieldCollectionTests.Verify_class=error_field=array-string-.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldCollectionTests.Verify_class=error_field=array-string-.verified.txt
@@ -6,8 +6,8 @@ namespace SchemaNamespace
     [global::System.CodeDom.Compiler.GeneratedCode("AvroSourceGenerator", "1.0.0.0")]
     public partial class Class
     {
-        public required global::System.Collections.Generic.IList<string> Field { get; init; }
-        public global::System.Collections.Generic.IList<string>? NullableField { get; init; }
+        public required global::System.Collections.Generic.List<string> Field { get; init; }
+        public global::System.Collections.Generic.List<string>? NullableField { get; init; }
     }
     
 }

--- a/tests/AvroSourceGenerator.Tests/FieldCollectionTests.Verify_class=error_field=map-string-.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldCollectionTests.Verify_class=error_field=map-string-.verified.txt
@@ -6,8 +6,8 @@ namespace SchemaNamespace
     [global::System.CodeDom.Compiler.GeneratedCode("AvroSourceGenerator", "1.0.0.0")]
     public partial class Class
     {
-        public required global::System.Collections.Generic.IDictionary<string, string> Field { get; init; }
-        public global::System.Collections.Generic.IDictionary<string, string>? NullableField { get; init; }
+        public required global::System.Collections.Generic.Dictionary<string, string> Field { get; init; }
+        public global::System.Collections.Generic.Dictionary<string, string>? NullableField { get; init; }
     }
     
 }

--- a/tests/AvroSourceGenerator.Tests/FieldCollectionTests.Verify_class=record_field=array-string-.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldCollectionTests.Verify_class=record_field=array-string-.verified.txt
@@ -6,8 +6,8 @@ namespace SchemaNamespace
     [global::System.CodeDom.Compiler.GeneratedCode("AvroSourceGenerator", "1.0.0.0")]
     public partial record Class
     {
-        public required global::System.Collections.Generic.IList<string> Field { get; init; }
-        public global::System.Collections.Generic.IList<string>? NullableField { get; init; }
+        public required global::System.Collections.Generic.List<string> Field { get; init; }
+        public global::System.Collections.Generic.List<string>? NullableField { get; init; }
     }
     
 }

--- a/tests/AvroSourceGenerator.Tests/FieldCollectionTests.Verify_class=record_field=map-string-.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/FieldCollectionTests.Verify_class=record_field=map-string-.verified.txt
@@ -6,8 +6,8 @@ namespace SchemaNamespace
     [global::System.CodeDom.Compiler.GeneratedCode("AvroSourceGenerator", "1.0.0.0")]
     public partial record Class
     {
-        public required global::System.Collections.Generic.IDictionary<string, string> Field { get; init; }
-        public global::System.Collections.Generic.IDictionary<string, string>? NullableField { get; init; }
+        public required global::System.Collections.Generic.Dictionary<string, string> Field { get; init; }
+        public global::System.Collections.Generic.Dictionary<string, string>? NullableField { get; init; }
     }
     
 }


### PR DESCRIPTION
- Updated `ArraySchema.cs` to use `List<T>` for arrays.
- Updated `MapSchema.cs` to use `Dictionary<string, T>` for maps.