### PR TITLE
Tidy diagnostics

### DIFF
--- a/src/AvroSourceGenerator/Configuration/AvroLibrary.cs
+++ b/src/AvroSourceGenerator/Configuration/AvroLibrary.cs
@@ -14,6 +14,9 @@ internal enum AvroLibraryReference
 
 internal static class AvroLibraryExtensions
 {
+    private static readonly string s_supportedPackageList =
+        string.Join(", ", Enum.GetValues(typeof(AvroLibraryReference)).OfType<AvroLibraryReference>().Select(x => $"'{x.PackageName}'"));
+
     extension(AvroLibraryReference reference)
     {
         public AvroLibrary ToAvroLibrary() => reference switch
@@ -27,5 +30,7 @@ internal static class AvroLibraryExtensions
             AvroLibraryReference.Apache => "Apache.Avro",
             _ => throw new InvalidOperationException($"Invalid {nameof(AvroLibraryReference)} '{reference}'"),
         };
+
+        public static string SupportedPackageList => s_supportedPackageList;
     }
 }

--- a/src/AvroSourceGenerator/Diagnostics/InvalidJsonDiagnostic.cs
+++ b/src/AvroSourceGenerator/Diagnostics/InvalidJsonDiagnostic.cs
@@ -1,10 +1,11 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using AvroSourceGenerator.Parsing;
+using Microsoft.CodeAnalysis;
 
 namespace AvroSourceGenerator.Diagnostics;
 
 internal static class InvalidJsonDiagnostic
 {
-    public static readonly DiagnosticDescriptor Descriptor = new(
+    private static readonly DiagnosticDescriptor s_descriptor = new(
         id: "AVROSG0001",
         title: "Invalid JSON",
         messageFormat: "The provided JSON is invalid: {0}",
@@ -15,6 +16,5 @@ internal static class InvalidJsonDiagnostic
         "The JSON supplied for an Avro schema could not be parsed. " +
         "Fix the JSON syntax (quotes, commas, braces, etc.). If the error reports a path, check that location first.");
 
-    public static Diagnostic Create(Location location, string message) =>
-        Diagnostic.Create(Descriptor, location, message);
+    public static DiagnosticInfo Create(LocationInfo location, string message) => new(s_descriptor, location, message);
 }

--- a/src/AvroSourceGenerator/Diagnostics/InvalidSchemaDiagnostic.cs
+++ b/src/AvroSourceGenerator/Diagnostics/InvalidSchemaDiagnostic.cs
@@ -1,10 +1,11 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using AvroSourceGenerator.Parsing;
+using Microsoft.CodeAnalysis;
 
 namespace AvroSourceGenerator.Diagnostics;
 
 internal static class InvalidSchemaDiagnostic
 {
-    public static readonly DiagnosticDescriptor Descriptor = new(
+    private static readonly DiagnosticDescriptor s_descriptor = new(
         id: "AVROSG0002",
         title: "Invalid Schema",
         messageFormat: "The schema defined in the JSON is invalid: {0}",
@@ -15,6 +16,5 @@ internal static class InvalidSchemaDiagnostic
         "The JSON parsed, but the Avro schema is not valid according to the Avro specification " +
         "(e.g., duplicate field names, invalid union members, unresolved references, etc.).");
 
-    public static Diagnostic Create(Location location, string message) =>
-        Diagnostic.Create(Descriptor, location, message);
+    public static DiagnosticInfo Create(LocationInfo location, string message) => new(s_descriptor, location, message);
 }

--- a/src/AvroSourceGenerator/Diagnostics/NoAvroLibraryDetectedDiagnostic.cs
+++ b/src/AvroSourceGenerator/Diagnostics/NoAvroLibraryDetectedDiagnostic.cs
@@ -1,20 +1,17 @@
 ﻿using AvroSourceGenerator.Configuration;
+using AvroSourceGenerator.Parsing;
 using Microsoft.CodeAnalysis;
 
 namespace AvroSourceGenerator.Diagnostics;
 
 internal static class NoAvroLibraryDetectedDiagnostic
 {
-    private static readonly string s_listOfLibraries = string.Join(
-        ", ",
-        Enum.GetValues(typeof(AvroLibraryReference)).OfType<AvroLibraryReference>().Select(x => x.PackageName));
-
-    public static readonly DiagnosticDescriptor Descriptor = new(
+    private static readonly DiagnosticDescriptor s_descriptor = new(
         id: "AVROSG0003",
         title: "No Avro library detected (Auto)",
         messageFormat:
         "AvroLibrary is set to 'Auto', but no supported Avro library was found. " +
-        "Generation will fall back to 'None' (no library-specific code). " +
+        "AvroSourceGenerator will fall back to 'None' (no library-specific code). " +
         "To target a specific library, install one of: {0}. " +
         "To keep this behavior without warnings, set AvroSourceGeneratorAvroLibrary to 'None' in your .csproj.",
         category: "Configuration",
@@ -26,6 +23,5 @@ internal static class NoAvroLibraryDetectedDiagnostic
         "Install a supported library to enable generation, or set <AvroSourceGeneratorAvroLibrary>None</AvroSourceGeneratorAvroLibrary> " +
         "explicitly to silence this warning.");
 
-    public static Diagnostic Create(Location location) =>
-        Diagnostic.Create(Descriptor, location, s_listOfLibraries);
+    public static DiagnosticInfo Create(LocationInfo location) => new(s_descriptor, location, AvroLibraryReference.SupportedPackageList);
 }

--- a/src/AvroSourceGenerator/Parsing/Parser.cs
+++ b/src/AvroSourceGenerator/Parsing/Parser.cs
@@ -22,7 +22,7 @@ internal static class Parser
         var diagnostics = ImmutableArray.CreateBuilder<DiagnosticInfo>();
         if (string.IsNullOrWhiteSpace(text))
         {
-            diagnostics.Add(new DiagnosticInfo(InvalidJsonDiagnostic.Descriptor, LocationInfo.FromSourceFile(path, text), "The file is empty."));
+            diagnostics.Add(InvalidJsonDiagnostic.Create(LocationInfo.FromSourceFile(path, text), "The file is empty."));
 
             return new AvroFile(path, text, default, default, diagnostics.ToImmutable());
         }
@@ -36,11 +36,11 @@ internal static class Parser
         }
         catch (JsonException ex)
         {
-            diagnostics.Add(new DiagnosticInfo(InvalidJsonDiagnostic.Descriptor, LocationInfo.FromException(path, text, ex), ex.Message));
+            diagnostics.Add(InvalidJsonDiagnostic.Create(LocationInfo.FromException(path, text, ex), ex.Message));
         }
         catch (InvalidSchemaException ex)
         {
-            diagnostics.Add(new DiagnosticInfo(InvalidSchemaDiagnostic.Descriptor, LocationInfo.FromSourceFile(path, text), ex.Message));
+            diagnostics.Add(InvalidSchemaDiagnostic.Create(LocationInfo.FromSourceFile(path, text), ex.Message));
         }
 
         return new AvroFile(path, text, default, default, diagnostics.ToImmutable());
@@ -130,11 +130,11 @@ internal static class Parser
                     return reference.ToAvroLibrary();
 
                 case []:
-                    diagnostics = [new DiagnosticInfo(NoAvroLibraryDetectedDiagnostic.Descriptor, LocationInfo.None)];
+                    diagnostics = [NoAvroLibraryDetectedDiagnostic.Create(LocationInfo.None)];
                     return AvroLibrary.None;
 
                 default:
-                    diagnostics = [new DiagnosticInfo(MultipleAvroLibrariesDetectedDiagnostic.Descriptor, LocationInfo.None, references)];
+                    diagnostics = [MultipleAvroLibrariesDetectedDiagnostic.Create(LocationInfo.None, references)];
                     return AvroLibrary.None;
             }
         }


### PR DESCRIPTION
This reverts to what was there before: exposing a create method instead of exposing the descriptor.

Small refactor to how libraries/references are displayed in the error messages.