### PR TITLE
Add render step

### DIFF
--- a/src/AvroSourceGenerator.Tracing/Program.cs
+++ b/src/AvroSourceGenerator.Tracing/Program.cs
@@ -1,8 +1,14 @@
 ﻿using Microsoft.Diagnostics.Tracing.Session;
 
+Console.WriteLine("TraceEventSession started.");
+
 // https://www.meziantou.net/measuring-performance-of-roslyn-source-generators.htm
 using var session = new TraceEventSession("roslyn-sg");
-Console.CancelKeyPress += (_, _) => session.Dispose();
+Console.CancelKeyPress += (_, _) =>
+{
+    Console.WriteLine("TraceEventSession ended.");
+    session.Dispose();
+};
 
 session.Source.Dynamic.AddCallbackForProviderEvent(
     "Microsoft-CodeAnalysis-General",
@@ -11,8 +17,8 @@ session.Source.Dynamic.AddCallbackForProviderEvent(
     {
         var generatorName = (string)traceEvent.PayloadByName("generatorName");
         var ticks = (long)traceEvent.PayloadByName("elapsedTicks");
-        //var id = (string)data.PayloadByName("id");
-        //var assemblyPath = (string)data.PayloadByName("assemblyPath");
+        // var id = (string)traceEvent.PayloadByName("id");
+        // var assemblyPath = (string)traceEvent.PayloadByName("assemblyPath");
 
         if (generatorName == "AvroSourceGenerator.AvroSourceGenerator")
             Console.WriteLine($"{generatorName}: {TimeSpan.FromTicks(ticks).TotalMilliseconds:N0}ms");

--- a/src/AvroSourceGenerator/AvroSourceGenerator.cs
+++ b/src/AvroSourceGenerator/AvroSourceGenerator.cs
@@ -22,13 +22,14 @@ public sealed class AvroSourceGenerator : IIncrementalGenerator
             .Select(Parser.GetCompilationInfo)
             .WithTrackingName(TrackingNames.CompilationInfo);
 
-        var renderSettings = generatorSettingsProvider.Combine(compilationInfoProvider)
+        var renderSettingsProvider = generatorSettingsProvider.Combine(compilationInfoProvider)
             .Select(Parser.GetRenderSettings)
             .WithTrackingName(TrackingNames.RenderSettings);
 
-        var emitterInputProvider = avroFileProvider.Combine(renderSettings)
-            .WithTrackingName(TrackingNames.EmitterInput);
+        var renderResultProvider = avroFileProvider.Combine(renderSettingsProvider)
+            .Select(Renderer.Render)
+            .WithTrackingName(TrackingNames.RenderResult);
 
-        context.RegisterImplementationSourceOutput(emitterInputProvider, Emitter.Emit);
+        context.RegisterImplementationSourceOutput(renderResultProvider, Emitter.Emit);
     }
 }

--- a/src/AvroSourceGenerator/Emit/Emitter.cs
+++ b/src/AvroSourceGenerator/Emit/Emitter.cs
@@ -1,10 +1,4 @@
 ﻿using System.Text;
-using System.Text.Json;
-using AvroSourceGenerator.Configuration;
-using AvroSourceGenerator.Diagnostics;
-using AvroSourceGenerator.Parsing;
-using AvroSourceGenerator.Registry;
-using AvroSourceGenerator.Schemas;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 
@@ -12,49 +6,16 @@ namespace AvroSourceGenerator.Emit;
 
 internal static class Emitter
 {
-    public static void Emit(SourceProductionContext context, (AvroFile avroFile, RenderSettings renderSettings) source)
+    public static void Emit(SourceProductionContext context, RenderResult result)
     {
-        var (avroFile, settings) = source;
-
-        foreach (var diagnostic in avroFile.Diagnostics)
+        foreach (var diagnostic in result.Diagnostics)
         {
             context.ReportDiagnostic(diagnostic);
         }
 
-        foreach (var diagnostic in settings.Diagnostics)
+        foreach (var schema in result.Schemas)
         {
-            context.ReportDiagnostic(diagnostic);
-        }
-
-        if (!avroFile.IsValid || !settings.IsValid)
-        {
-            return;
-        }
-
-        try
-        {
-            var schemaRegistry = SchemaRegistry.Register(
-                schema: avroFile.Json,
-                avroLibrary: settings.AvroLibrary,
-                languageVersion: settings.LanguageVersion,
-                useNullableReferenceTypes: settings.LanguageFeatures.HasFlag(LanguageFeatures.NullableReferenceTypes));
-
-            // We should get no render errors, so we don't have to handle anything else.
-            var renderOutputs = AvroTemplate.Render(schemaRegistry, settings);
-
-            foreach (var renderOutput in renderOutputs)
-            {
-                context.AddSource(renderOutput.HintName, SourceText.From(renderOutput.SourceText, Encoding.UTF8));
-            }
-        }
-        catch (JsonException ex)
-        {
-            context.ReportDiagnostic(InvalidJsonDiagnostic.Create(LocationInfo.FromException(avroFile.Path, avroFile.Text, ex), ex.Message));
-        }
-        catch (InvalidSchemaException ex)
-        {
-            // TODO: We can probably get a better location for the error.
-            context.ReportDiagnostic(InvalidSchemaDiagnostic.Create(LocationInfo.FromSourceFile(avroFile.Path, avroFile.Text), ex.Message));
+            context.AddSource(schema.HintName, SourceText.From(schema.SourceText, Encoding.UTF8));
         }
     }
 }

--- a/src/AvroSourceGenerator/Emit/RenderOutput.cs
+++ b/src/AvroSourceGenerator/Emit/RenderOutput.cs
@@ -1,3 +1,0 @@
-﻿namespace AvroSourceGenerator.Emit;
-
-internal readonly record struct RenderOutput(string HintName, string SourceText);

--- a/src/AvroSourceGenerator/Emit/RenderResult.cs
+++ b/src/AvroSourceGenerator/Emit/RenderResult.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Immutable;
+using AvroSourceGenerator.Diagnostics;
+
+namespace AvroSourceGenerator.Emit;
+
+internal readonly record struct RenderResult(ImmutableArray<RenderedSchema> Schemas, ImmutableArray<DiagnosticInfo> Diagnostics)
+{
+    public bool Equals(RenderResult other) => Schemas.OrderBy(x => x.HintName).SequenceEqual(other.Schemas.OrderBy(x => x.HintName));
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        foreach (var schema in Schemas)
+            hash.Add(schema.GetHashCode());
+        return hash.ToHashCode();
+    }
+}

--- a/src/AvroSourceGenerator/Emit/RenderedSchema.cs
+++ b/src/AvroSourceGenerator/Emit/RenderedSchema.cs
@@ -1,0 +1,3 @@
+﻿namespace AvroSourceGenerator.Emit;
+
+internal readonly record struct RenderedSchema(string HintName, string SourceText);

--- a/src/AvroSourceGenerator/Emit/Renderer.cs
+++ b/src/AvroSourceGenerator/Emit/Renderer.cs
@@ -1,0 +1,48 @@
+﻿using System.Text.Json;
+using AvroSourceGenerator.Configuration;
+using AvroSourceGenerator.Diagnostics;
+using AvroSourceGenerator.Parsing;
+using AvroSourceGenerator.Registry;
+using AvroSourceGenerator.Schemas;
+
+namespace AvroSourceGenerator.Emit;
+
+internal static class Renderer
+{
+    public static RenderResult Render((AvroFile avroFile, RenderSettings renderSettings) source, CancellationToken cancellationToken)
+    {
+        var (avroFile, settings) = source;
+
+        var diagnostics = avroFile.Diagnostics.AddRange(settings.Diagnostics);
+
+        if (!avroFile.IsValid || !settings.IsValid)
+        {
+            return new RenderResult([], diagnostics);
+        }
+
+        try
+        {
+            var schemaRegistry = SchemaRegistry.Register(
+                schema: avroFile.Json,
+                avroLibrary: settings.AvroLibrary,
+                languageVersion: settings.LanguageVersion,
+                useNullableReferenceTypes: settings.LanguageFeatures.HasFlag(LanguageFeatures.NullableReferenceTypes));
+
+            // We should get no render errors, so we don't have to handle anything else.
+            var schemas = AvroTemplate.Render(schemaRegistry, settings);
+
+            return new RenderResult(schemas, diagnostics);
+        }
+        catch (JsonException ex)
+        {
+            diagnostics = diagnostics.Add(InvalidJsonDiagnostic.Create(LocationInfo.FromException(avroFile.Path, avroFile.Text, ex), ex.Message));
+        }
+        catch (InvalidSchemaException ex)
+        {
+            // TODO: We can probably get a better location for the error.
+            diagnostics = diagnostics.Add(InvalidSchemaDiagnostic.Create(LocationInfo.FromSourceFile(avroFile.Path, avroFile.Text), ex.Message));
+        }
+
+        return new RenderResult([], diagnostics);
+    }
+}

--- a/src/AvroSourceGenerator/Parsing/RenderSettings.cs
+++ b/src/AvroSourceGenerator/Parsing/RenderSettings.cs
@@ -13,7 +13,7 @@ internal readonly record struct RenderSettings(
     string RecordDeclaration,
     ImmutableArray<DiagnosticInfo> Diagnostics)
 {
-    public bool IsValid => Diagnostics.IsDefaultOrEmpty;
+    public bool IsValid => !Diagnostics.Any(x => x.Descriptor.DefaultSeverity is Microsoft.CodeAnalysis.DiagnosticSeverity.Error);
 
     public bool Equals(RenderSettings other) =>
         AvroLibrary == other.AvroLibrary &&

--- a/src/AvroSourceGenerator/Parsing/TrackingNames.cs
+++ b/src/AvroSourceGenerator/Parsing/TrackingNames.cs
@@ -6,5 +6,6 @@ internal static class TrackingNames
     public const string GeneratorSettings = nameof(GeneratorSettings);
     public const string CompilationInfo = nameof(CompilationInfo);
     public const string RenderSettings = nameof(RenderSettings);
+    public const string RenderResult = nameof(RenderResult);
     public const string EmitterInput = nameof(EmitterInput);
 }


### PR DESCRIPTION
This step caches the rendering of each file. The emitter will now only output source files.

### Before
```mermaid
flowchart TD
    A[.avsc] --> E[Emit]
    B[.csproj] --> D
    C[compilation] --> D
    D[configuration] --> E
```

### After
```mermaid
flowchart TD
    A[.avsc] --> E
    B[.csproj] --> D
    C[compilation] --> D
    D[configuration] --> E
    E[Render] --> F[Emit]
```