### PR TITLE
Add support for record declarations for all complex types

### DIFF
--- a/src/AvroSourceGenerator/Emit/TemplateScriptObject.cs
+++ b/src/AvroSourceGenerator/Emit/TemplateScriptObject.cs
@@ -23,7 +23,9 @@ internal sealed class TemplateScriptObject : BuiltinFunctions
             readOnly: true);
         SetValue("AvroLibrary", settings.AvroLibrary, readOnly: true);
         SetValue("AccessModifier", settings.AccessModifier, readOnly: true);
-        SetValue("RecordDeclaration", settings.RecordDeclaration, readOnly: true);
+        SetValue("Record", settings.Declaration.Record, readOnly: true);
+        SetValue("Error", settings.Declaration.Error, readOnly: true);
+        SetValue("Fixed", settings.Declaration.Fixed, readOnly: true);
         SetValue(
             "UseNullableReferenceTypes",
             (settings.LanguageFeatures & LanguageFeatures.NullableReferenceTypes) != 0,

--- a/src/AvroSourceGenerator/Parsing/RenderSettings.cs
+++ b/src/AvroSourceGenerator/Parsing/RenderSettings.cs
@@ -5,12 +5,21 @@ using Microsoft.CodeAnalysis.CSharp;
 
 namespace AvroSourceGenerator.Parsing;
 
+internal sealed record class Declaration(string Record, string Fixed, string Error)
+{
+    public static Declaration Records { get; } = new("record", "class", "class");
+    public static Declaration Classes { get; } = new("class", "class", "class");
+
+    public static Declaration ApacheRecords { get; } = new("record", "class", "class");
+    public static Declaration ApacheClasses { get; } = new("class", "class", "class");
+}
+
 internal readonly record struct RenderSettings(
     AvroLibrary AvroLibrary,
     LanguageVersion LanguageVersion,
     LanguageFeatures LanguageFeatures,
     string AccessModifier,
-    string RecordDeclaration,
+    Declaration Declaration,
     DuplicateResolution DuplicateResolution,
     ImmutableArray<DiagnosticInfo> Diagnostics)
 {
@@ -21,7 +30,7 @@ internal readonly record struct RenderSettings(
         LanguageVersion == other.LanguageVersion &&
         LanguageFeatures == other.LanguageFeatures &&
         AccessModifier == other.AccessModifier &&
-        RecordDeclaration == other.RecordDeclaration &&
+        Declaration == other.Declaration &&
         // This will not avoid all cases, but it's good enough for now.
         Diagnostics.OrderBy(x => x.Descriptor.Id).SequenceEqual(other.Diagnostics.OrderBy(x => x.Descriptor.Id));
 
@@ -32,7 +41,7 @@ internal readonly record struct RenderSettings(
         hash.Add(LanguageVersion);
         hash.Add(LanguageFeatures);
         hash.Add(AccessModifier);
-        hash.Add(RecordDeclaration);
+        hash.Add(Declaration);
         foreach (var diagnostic in Diagnostics)
             hash.Add(diagnostic);
 

--- a/src/AvroSourceGenerator/Templates/abstract.sbncs
+++ b/src/AvroSourceGenerator/Templates/abstract.sbncs
@@ -1,1 +1,1 @@
-{{ AccessModifier }} abstract partial {{ RecordDeclaration }} {{ $.schema.CSharpName.Name }};
+{{ AccessModifier }} abstract partial {{ Record }} {{ $.schema.CSharpName.Name }};

--- a/src/AvroSourceGenerator/Templates/error.sbncs
+++ b/src/AvroSourceGenerator/Templates/error.sbncs
@@ -1,11 +1,11 @@
-{{ AccessModifier }} partial class {{ $.schema.CSharpName.Name }}
+{{ AccessModifier }} partial {{ Error }} {{ $.schema.CSharpName.Name }}
 {
     {{~ for field in $.schema.Fields ~}}
     {{ include 'field' field: field }}
     {{~ end ~}}
 }
 {{ if AvroLibrary == 'Apache' }}
-partial class {{ $.schema.CSharpName.Name }} : global::Avro.Specific.SpecificException
+partial {{ Error }} {{ $.schema.CSharpName.Name }} : global::Avro.Specific.SpecificException
 {
     public override global::Avro.Schema Schema { get => {{ $.schema.CSharpName.Name }}.s_schema; }
     private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(

--- a/src/AvroSourceGenerator/Templates/fixed.sbncs
+++ b/src/AvroSourceGenerator/Templates/fixed.sbncs
@@ -1,4 +1,4 @@
-{{ AccessModifier }} partial class {{ $.schema.CSharpName.Name }}
+{{ AccessModifier }} partial {{ Fixed }} {{ $.schema.CSharpName.Name }}
 {
     public int Size { get => {{ $.schema.Size }}; }
     {{~ if AvroLibrary == 'None' ~}}
@@ -6,7 +6,7 @@
     {{~ end ~}}
 }
 {{ if AvroLibrary == 'Apache' }}
-partial class {{ $.schema.CSharpName.Name }} : global::Avro.Specific.SpecificFixed
+partial {{ Fixed }} {{ $.schema.CSharpName.Name }} : global::Avro.Specific.SpecificFixed
 {
     public {{ $.schema.CSharpName.Name }}() : base({{ $.schema.Size }}) { }
 

--- a/src/AvroSourceGenerator/Templates/record.sbncs
+++ b/src/AvroSourceGenerator/Templates/record.sbncs
@@ -1,11 +1,11 @@
-{{ AccessModifier }} partial {{ RecordDeclaration }} {{ $.schema.CSharpName.Name }}{{ if $.schema.InheritsFrom }} : {{ $.schema.InheritsFrom.CSharpName }}{{ end }}
+{{ AccessModifier }} partial {{ Record }} {{ $.schema.CSharpName.Name }}{{ if $.schema.InheritsFrom }} : {{ $.schema.InheritsFrom.CSharpName }}{{ end }}
 {
     {{~ for field in $.schema.Fields ~}}
     {{ include 'field' field: field }}
     {{~ end ~}}
 }
 {{ if AvroLibrary == 'Apache' }}
-partial {{ RecordDeclaration }} {{ $.schema.CSharpName.Name }} : global::Avro.Specific.ISpecificRecord
+partial {{ Record }} {{ $.schema.CSharpName.Name }} : global::Avro.Specific.ISpecificRecord
 {
     global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => {{ $.schema.CSharpName.Name }}.s_schema; }
     private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(


### PR DESCRIPTION
There is no reason to disallow records for Fixed and Error types when generating code for other libraries beside Avro.