### PR TITLE
Use interfaces as union root instead of abstract classes.

### DIFF
--- a/src/AvroSourceGenerator/Registry/SchemaRegistry.Schema.Fields.cs
+++ b/src/AvroSourceGenerator/Registry/SchemaRegistry.Schema.Fields.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Immutable;
-using System.Text;
 using System.Text.Json;
 using AvroSourceGenerator.Registry.Extensions;
 using AvroSourceGenerator.Schemas;
@@ -70,14 +69,9 @@ internal readonly partial struct SchemaRegistry
 
         static string MakeVariantName(string schemaName, string fieldName)
         {
-            var builder = new StringBuilder(schemaName.Length + fieldName.Length + 7)
-                .Append(schemaName)
-                .Append(fieldName)
-                .Append("Variant");
-
-            builder[schemaName.Length] = char.ToUpperInvariant(builder[schemaName.Length]);
-
-            return builder.ToString();
+            char[] name = ['I', .. schemaName.AsSpan(), .. fieldName.AsSpan(), 'V', 'a', 'r', 'i', 'a', 'n', 't'];
+            name[schemaName.Length + 1] = char.ToUpperInvariant(fieldName[0]);
+            return new string(name);
         }
 
         static bool IsEligibleForAbstractRecord(UnionSchema union)

--- a/src/AvroSourceGenerator/Templates/abstract.sbncs
+++ b/src/AvroSourceGenerator/Templates/abstract.sbncs
@@ -1,1 +1,1 @@
-{{ AccessModifier }} abstract partial {{ Record }} {{ $.schema.CSharpName.Name }};
+{{ AccessModifier }} partial interface {{ $.schema.CSharpName.Name }};

--- a/tests/AvroSourceGenerator.IntegrationTests.Apache/JsonEqualityComparer.cs
+++ b/tests/AvroSourceGenerator.IntegrationTests.Apache/JsonEqualityComparer.cs
@@ -49,7 +49,7 @@ file sealed class FixedJsonConverterFactory : JsonConverterFactory
         {
             if (reader.TokenType != JsonTokenType.String)
                 throw new JsonException($"Expected string token, but got {reader.TokenType}.");
-            var @fixed = Activator.CreateInstance<T>()!;
+            var @fixed = Activator.CreateInstance<T>();
             @fixed.Value = Convert.FromBase64String(reader.GetString()!);
             return @fixed;
         }

--- a/tests/AvroSourceGenerator.IntegrationTests.Apache/KafkaRoundTripTests.cs
+++ b/tests/AvroSourceGenerator.IntegrationTests.Apache/KafkaRoundTripTests.cs
@@ -152,8 +152,7 @@ public class KafkaRoundTripTests(DockerFixture dockerFixture)
 
     [Theory]
     [MemberData(nameof(NotificationVariants))]
-    public async Task Union_types_mapped_to_abstract_remain_unchanged_after_roundtrip_to_kafka(
-        NotificationContentVariant content)
+    public async Task Union_types_mapped_to_abstract_remain_unchanged_after_roundtrip_to_kafka(INotificationContentVariant content)
     {
         var expected = new Notification { content = content };
 
@@ -162,7 +161,7 @@ public class KafkaRoundTripTests(DockerFixture dockerFixture)
         AssertEqual(expected, actual);
     }
 
-    public static TheoryData<NotificationContentVariant> NotificationVariants() =>
+    public static TheoryData<INotificationContentVariant> NotificationVariants() =>
     [
         new EmailContent
         {

--- a/tests/AvroSourceGenerator.Tests/UnionAbstractBaseTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionAbstractBaseTests.Verify#00.verified.txt
@@ -4,7 +4,7 @@
 namespace com.example.notifications
 {
     [global::System.CodeDom.Compiler.GeneratedCode("AvroSourceGenerator", "1.0.0.0")]
-    public partial record EmailContent : global::com.example.notifications.NotificationContentVariant
+    public partial record EmailContent : global::com.example.notifications.INotificationContentVariant
     {
         public required string subject { get; init; }
         public required string body { get; init; }

--- a/tests/AvroSourceGenerator.Tests/UnionAbstractBaseTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionAbstractBaseTests.Verify#01.verified.txt
@@ -4,7 +4,7 @@
 namespace com.example.notifications
 {
     [global::System.CodeDom.Compiler.GeneratedCode("AvroSourceGenerator", "1.0.0.0")]
-    public partial record SmsContent : global::com.example.notifications.NotificationContentVariant
+    public partial record SmsContent : global::com.example.notifications.INotificationContentVariant
     {
         public required string message { get; init; }
         public required string phoneNumber { get; init; }

--- a/tests/AvroSourceGenerator.Tests/UnionAbstractBaseTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionAbstractBaseTests.Verify#02.verified.txt
@@ -4,7 +4,7 @@
 namespace com.example.notifications
 {
     [global::System.CodeDom.Compiler.GeneratedCode("AvroSourceGenerator", "1.0.0.0")]
-    public partial record PushContent : global::com.example.notifications.NotificationContentVariant
+    public partial record PushContent : global::com.example.notifications.INotificationContentVariant
     {
         public required string title { get; init; }
         public required string message { get; init; }

--- a/tests/AvroSourceGenerator.Tests/UnionAbstractBaseTests.Verify#03.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionAbstractBaseTests.Verify#03.verified.txt
@@ -11,6 +11,6 @@ namespace com.example.notifications
     /// </list>
     /// </summary>
     [global::System.CodeDom.Compiler.GeneratedCode("AvroSourceGenerator", "1.0.0.0")]
-    public abstract partial record NotificationContentVariant;
+    public partial interface INotificationContentVariant;
 }
 #pragma warning restore CS8618, CS8633, CS8714, CS8775

--- a/tests/AvroSourceGenerator.Tests/UnionAbstractBaseTests.Verify#04.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionAbstractBaseTests.Verify#04.verified.txt
@@ -17,7 +17,7 @@ namespace com.example.notifications
         /// <item><see cref="global::com.example.notifications.SmsContent"/></item>
         /// </list>
         /// </remarks>
-        public required global::com.example.notifications.NotificationContentVariant content { get; init; }
+        public required global::com.example.notifications.INotificationContentVariant content { get; init; }
     }
     
 }

--- a/tests/AvroSourceGenerator.Tests/UnionAbstractNullableBaseTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionAbstractNullableBaseTests.Verify#00.verified.txt
@@ -4,7 +4,7 @@
 namespace com.example.notifications
 {
     [global::System.CodeDom.Compiler.GeneratedCode("AvroSourceGenerator", "1.0.0.0")]
-    public partial record EmailContent : global::com.example.notifications.NotificationContentVariant
+    public partial record EmailContent : global::com.example.notifications.INotificationContentVariant
     {
         public required string subject { get; init; }
         public required string body { get; init; }

--- a/tests/AvroSourceGenerator.Tests/UnionAbstractNullableBaseTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionAbstractNullableBaseTests.Verify#01.verified.txt
@@ -4,7 +4,7 @@
 namespace com.example.notifications
 {
     [global::System.CodeDom.Compiler.GeneratedCode("AvroSourceGenerator", "1.0.0.0")]
-    public partial record SmsContent : global::com.example.notifications.NotificationContentVariant
+    public partial record SmsContent : global::com.example.notifications.INotificationContentVariant
     {
         public required string message { get; init; }
         public required string phoneNumber { get; init; }

--- a/tests/AvroSourceGenerator.Tests/UnionAbstractNullableBaseTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionAbstractNullableBaseTests.Verify#02.verified.txt
@@ -4,7 +4,7 @@
 namespace com.example.notifications
 {
     [global::System.CodeDom.Compiler.GeneratedCode("AvroSourceGenerator", "1.0.0.0")]
-    public partial record PushContent : global::com.example.notifications.NotificationContentVariant
+    public partial record PushContent : global::com.example.notifications.INotificationContentVariant
     {
         public required string title { get; init; }
         public required string message { get; init; }

--- a/tests/AvroSourceGenerator.Tests/UnionAbstractNullableBaseTests.Verify#03.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionAbstractNullableBaseTests.Verify#03.verified.txt
@@ -12,6 +12,6 @@ namespace com.example.notifications
     /// </list>
     /// </summary>
     [global::System.CodeDom.Compiler.GeneratedCode("AvroSourceGenerator", "1.0.0.0")]
-    public abstract partial record NotificationContentVariant;
+    public partial interface INotificationContentVariant;
 }
 #pragma warning restore CS8618, CS8633, CS8714, CS8775

--- a/tests/AvroSourceGenerator.Tests/UnionAbstractNullableBaseTests.Verify#04.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionAbstractNullableBaseTests.Verify#04.verified.txt
@@ -18,7 +18,7 @@ namespace com.example.notifications
         /// <item><see cref="global::com.example.notifications.SmsContent"/></item>
         /// </list>
         /// </remarks>
-        public global::com.example.notifications.NotificationContentVariant? content { get; init; }
+        public global::com.example.notifications.INotificationContentVariant? content { get; init; }
     }
     
 }

--- a/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#03.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#03.verified.txt
@@ -4,7 +4,7 @@
 namespace com.example.user
 {
     [global::System.CodeDom.Compiler.GeneratedCode("AvroSourceGenerator", "1.0.0.0")]
-    public partial record EmailContact : global::com.example.user.UserProfileContactVariant
+    public partial record EmailContact : global::com.example.user.IUserProfileContactVariant
     {
         public required string email { get; init; }
     }

--- a/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#04.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#04.verified.txt
@@ -4,7 +4,7 @@
 namespace com.example.user
 {
     [global::System.CodeDom.Compiler.GeneratedCode("AvroSourceGenerator", "1.0.0.0")]
-    public partial record PhoneContact : global::com.example.user.UserProfileContactVariant
+    public partial record PhoneContact : global::com.example.user.IUserProfileContactVariant
     {
         public required string phoneNumber { get; init; }
     }

--- a/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#05.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#05.verified.txt
@@ -11,6 +11,6 @@ namespace com.example.user
     /// </list>
     /// </summary>
     [global::System.CodeDom.Compiler.GeneratedCode("AvroSourceGenerator", "1.0.0.0")]
-    public abstract partial record UserProfileContactVariant;
+    public partial interface IUserProfileContactVariant;
 }
 #pragma warning restore CS8618, CS8633, CS8714, CS8775

--- a/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#06.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/UnionWithNullTests.Verify#06.verified.txt
@@ -36,7 +36,7 @@ namespace com.example.user
         /// <item><see cref="global::com.example.user.PhoneContact"/></item>
         /// </list>
         /// </remarks>
-        public global::com.example.user.UserProfileContactVariant? contact { get; init; }
+        public global::com.example.user.IUserProfileContactVariant? contact { get; init; }
     }
     
 }

--- a/tests/Schemas/Notification.cs
+++ b/tests/Schemas/Notification.cs
@@ -11,16 +11,11 @@ partial record Notification { }
     "Extensibility",
     "xUnit3001:Classes that are marked as serializable (or created by the test framework at runtime) must have a public parameterless constructor",
     Justification = "<Pending>")]
-partial record NotificationContentVariant : IXunitSerializable
-{
-    public abstract void Deserialize(IXunitSerializationInfo info);
+partial interface INotificationContentVariant : IXunitSerializable;
 
-    public abstract void Serialize(IXunitSerializationInfo info);
-}
-
-partial record EmailContent : IXunitSerializable
+partial record EmailContent
 {
-    public override void Deserialize(IXunitSerializationInfo info)
+    public void Deserialize(IXunitSerializationInfo info)
     {
         SetSubject(this, (string)info.GetValue(nameof(subject))!);
         SetBody(this, (string)info.GetValue(nameof(body))!);
@@ -38,7 +33,7 @@ partial record EmailContent : IXunitSerializable
         static extern void SetRecipientEmail(EmailContent obj, string value);
     }
 
-    public override void Serialize(IXunitSerializationInfo info)
+    public void Serialize(IXunitSerializationInfo info)
     {
         info.AddValue(nameof(subject), subject);
         info.AddValue(nameof(body), body);
@@ -48,7 +43,7 @@ partial record EmailContent : IXunitSerializable
 
 partial record PushContent : IXunitSerializable
 {
-    public override void Deserialize(IXunitSerializationInfo info)
+    public void Deserialize(IXunitSerializationInfo info)
     {
         SetTitle(this, (string)info.GetValue(nameof(title))!);
         SetMessage(this, (string)info.GetValue(nameof(message))!);
@@ -66,7 +61,7 @@ partial record PushContent : IXunitSerializable
         static extern void SetDeviceToken(PushContent obj, string value);
     }
 
-    public override void Serialize(IXunitSerializationInfo info)
+    public void Serialize(IXunitSerializationInfo info)
     {
         info.AddValue(nameof(title), title);
         info.AddValue(nameof(message), message);
@@ -76,7 +71,7 @@ partial record PushContent : IXunitSerializable
 
 partial record SmsContent : IXunitSerializable
 {
-    public override void Deserialize(IXunitSerializationInfo info)
+    public void Deserialize(IXunitSerializationInfo info)
     {
         SetMessage(this, (string)info.GetValue(nameof(message))!);
         SetPhoneNumber(this, (string)info.GetValue(nameof(phoneNumber))!);
@@ -90,7 +85,7 @@ partial record SmsContent : IXunitSerializable
         static extern void SetPhoneNumber(SmsContent obj, string value);
     }
 
-    public override void Serialize(IXunitSerializationInfo info)
+    public void Serialize(IXunitSerializationInfo info)
     {
         info.AddValue(nameof(message), message);
         info.AddValue(nameof(phoneNumber), phoneNumber);


### PR DESCRIPTION
Why use interfaces for union roots?

- Enable value types — allows struct/record struct union members and reduces heap allocations.
- Lower overhead — avoids base-class inheritance and virtual dispatch costs.
- Better modeling — unions represent alternatives, not true inheritance hierarchies.
- Safer evolution — avoids fragile base-class coupling and breaking changes.
- More extensible — implementations can still inherit from other base classes.
- Cleaner generated API — simpler, more flexible surface for consumers.