### PR TITLE
Use `AvroSchemaReference` to specify references instead of using the actual schema

### DIFF
--- a/src/AvroSourceGenerator/Emit/TemplateScriptObject.cs
+++ b/src/AvroSourceGenerator/Emit/TemplateScriptObject.cs
@@ -1,7 +1,5 @@
-﻿using System.Text.Json;
-using AvroSourceGenerator.Configuration;
+﻿using AvroSourceGenerator.Configuration;
 using AvroSourceGenerator.Parsing;
-using AvroSourceGenerator.Schemas;
 using Scriban.Functions;
 using Scriban.Runtime;
 
@@ -9,18 +7,13 @@ namespace AvroSourceGenerator.Emit;
 
 internal sealed class TemplateScriptObject : BuiltinFunctions
 {
-    private static readonly DynamicCustomFunction s_jsonRawString = CreateFunction(static (AvroSchema schema) =>
-        string.Join("\n", "\"\"\"", schema.ToJsonString(new JsonWriterOptions { Indented = true }), "\"\"\""));
-
-    private static readonly DynamicCustomFunction s_jsonVerbatimString = CreateFunction(static (AvroSchema schema) =>
-        StringFunctions.Literal(schema.ToJsonString()));
-
-    public TemplateScriptObject(RenderSettings settings)
+    public TemplateScriptObject(RenderSettings settings, DynamicCustomFunction? renderJsonSchema)
     {
-        SetValue(
-            "json",
-            (settings.LanguageFeatures & LanguageFeatures.RawStringLiterals) != 0 ? s_jsonRawString : s_jsonVerbatimString,
-            readOnly: true);
+        if (renderJsonSchema is not null)
+        {
+            SetValue("json", renderJsonSchema, readOnly: true);
+        }
+
         SetValue("AvroLibrary", settings.AvroLibrary, readOnly: true);
         SetValue("AccessModifier", settings.AccessModifier, readOnly: true);
         SetValue("Record", settings.Declaration.Record, readOnly: true);
@@ -41,7 +34,4 @@ internal sealed class TemplateScriptObject : BuiltinFunctions
         SetValue("UseRawStringLiterals", (settings.LanguageFeatures & LanguageFeatures.RawStringLiterals) != 0, readOnly: true);
         SetValue("UseUnsafeAccessors", (settings.LanguageFeatures & LanguageFeatures.UnsafeAccessors) != 0, readOnly: true);
     }
-
-    private static DynamicCustomFunction CreateFunction(Delegate @delegate) =>
-        DynamicCustomFunction.Create(@delegate);
 }

--- a/src/AvroSourceGenerator/Registry/SchemaRegistry.cs
+++ b/src/AvroSourceGenerator/Registry/SchemaRegistry.cs
@@ -29,6 +29,8 @@ internal readonly partial struct SchemaRegistry(
     public IEnumerator<TopLevelSchema> GetEnumerator() => _schemas.Values.GetEnumerator();
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
+    public IReadOnlyDictionary<SchemaName, TopLevelSchema> Schemas => _schemas;
+
     public static SchemaRegistry Register(
         JsonElement schema,
         AvroLibrary avroLibrary,
@@ -62,8 +64,8 @@ internal readonly partial struct SchemaRegistry(
         }
 
         var schemaName = name.GetRequiredSchemaName(containingNamespace);
-        if (_schemas.TryGetValue(schemaName, out var topLevelSchema) && topLevelSchema is NamedSchema namedSchema)
-            return namedSchema;
+        if (_schemas.TryGetValue(schemaName, out var topLevelSchema) && topLevelSchema is NamedSchema)
+            return new AvroSchemaReference(topLevelSchema.SchemaName);
 
         return null;
     }

--- a/src/AvroSourceGenerator/Schemas/ArraySchema.cs
+++ b/src/AvroSourceGenerator/Schemas/ArraySchema.cs
@@ -6,12 +6,12 @@ namespace AvroSourceGenerator.Schemas;
 internal sealed record class ArraySchema(AvroSchema ItemSchema, ImmutableSortedDictionary<string, JsonElement> Properties)
     : AvroSchema(SchemaType.Array, new CSharpName($"List<{ItemSchema}>", "System.Collections.Generic"), new SchemaName("array"), Properties)
 {
-    public override void WriteTo(Utf8JsonWriter writer, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
+    public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {
         writer.WriteStartObject();
         writer.WriteString("type", "array");
         writer.WritePropertyName("items");
-        ItemSchema.WriteTo(writer, writtenSchemas, containingNamespace);
+        ItemSchema.WriteTo(writer, registeredSchemas, writtenSchemas, containingNamespace);
         foreach (var entry in Properties)
         {
             writer.WritePropertyName(entry.Key);

--- a/src/AvroSourceGenerator/Schemas/AvroSchema.cs
+++ b/src/AvroSourceGenerator/Schemas/AvroSchema.cs
@@ -15,16 +15,16 @@ internal abstract record class AvroSchema(
 
     public sealed override string ToString() => CSharpName.FullName;
 
-    public string ToJsonString(JsonWriterOptions options = default)
+    public string ToJsonString(IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, JsonWriterOptions options = default)
     {
         using var stream = new MemoryStream();
         using var writer = new Utf8JsonWriter(stream, options);
-        WriteTo(writer, [], SchemaName.Namespace);
+        WriteTo(writer, registeredSchemas, [], SchemaName.Namespace);
         writer.Flush();
         return Encoding.UTF8.GetString(stream.ToArray());
     }
 
-    public abstract void WriteTo(Utf8JsonWriter writer, HashSet<SchemaName> writtenSchemas, string? containingNamespace);
+    public abstract void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace);
 
     public static readonly PrimitiveSchema Object = new(SchemaType.Null, new CSharpName("object"), new SchemaName("null"));
     public static readonly PrimitiveSchema Boolean = new(SchemaType.Boolean, new CSharpName("bool"), new SchemaName("boolean"));

--- a/src/AvroSourceGenerator/Schemas/AvroSchemaReference.cs
+++ b/src/AvroSourceGenerator/Schemas/AvroSchemaReference.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Immutable;
+using System.Text.Json;
+
+namespace AvroSourceGenerator.Schemas;
+
+internal sealed record class AvroSchemaReference(SchemaName SchemaName)
+    : AvroSchema(SchemaType.Reference, CSharpName.FromSchemaName(SchemaName), SchemaName, ImmutableSortedDictionary<string, JsonElement>.Empty)
+{
+    public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
+    {
+        if (writtenSchemas.Contains(SchemaName))
+        {
+            writer.WriteStringValue(SchemaName.Namespace == containingNamespace ? SchemaName.Name : SchemaName.FullName);
+            return;
+        }
+
+        registeredSchemas[SchemaName].WriteTo(writer, registeredSchemas, writtenSchemas, containingNamespace);
+    }
+}

--- a/src/AvroSourceGenerator/Schemas/EnumSchema.cs
+++ b/src/AvroSourceGenerator/Schemas/EnumSchema.cs
@@ -13,7 +13,7 @@ internal sealed record class EnumSchema(
     ImmutableSortedDictionary<string, JsonElement> Properties)
     : NamedSchema(SchemaType.Enum, Json, SchemaName, Documentation, Aliases, Properties)
 {
-    public override void WriteTo(Utf8JsonWriter writer, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
+    public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {
         if (!writtenSchemas.Add(SchemaName))
         {

--- a/src/AvroSourceGenerator/Schemas/ErrorSchema.cs
+++ b/src/AvroSourceGenerator/Schemas/ErrorSchema.cs
@@ -12,7 +12,7 @@ internal sealed record class ErrorSchema(
     ImmutableSortedDictionary<string, JsonElement> Properties)
     : NamedSchema(SchemaType.Error, Json, SchemaName, Documentation, Aliases, Properties)
 {
-    public override void WriteTo(Utf8JsonWriter writer, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
+    public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {
         if (!writtenSchemas.Add(SchemaName))
         {
@@ -39,7 +39,7 @@ internal sealed record class ErrorSchema(
 
         writer.WriteStartArray("fields");
         foreach (var field in Fields)
-            field.WriteTo(writer, writtenSchemas, @namespace);
+            field.WriteTo(writer, writtenSchemas, registeredSchemas, @namespace);
         writer.WriteEndArray();
         foreach (var entry in Properties)
         {

--- a/src/AvroSourceGenerator/Schemas/Field.cs
+++ b/src/AvroSourceGenerator/Schemas/Field.cs
@@ -16,13 +16,13 @@ internal sealed record class Field(
     ImmutableSortedDictionary<string, JsonElement> Properties,
     string? Remarks)
 {
-    public void WriteTo(Utf8JsonWriter writer, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
+    public void WriteTo(Utf8JsonWriter writer, HashSet<SchemaName> writtenSchemas, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, string? containingNamespace)
     {
         writer.WriteStartObject();
         // TODO: Is it worth to store the schema name?
         writer.WriteString("name", Name is ['@', ..] ? Name[1..] : Name);
         writer.WritePropertyName("type");
-        Type.WriteTo(writer, writtenSchemas, containingNamespace);
+        Type.WriteTo(writer, registeredSchemas, writtenSchemas, containingNamespace);
         if (Documentation is not null)
             writer.WriteString("doc", Documentation);
         if (Aliases.Length > 0)

--- a/src/AvroSourceGenerator/Schemas/FixedSchema.cs
+++ b/src/AvroSourceGenerator/Schemas/FixedSchema.cs
@@ -28,7 +28,7 @@ internal sealed record class FixedSchema(
 
     public override bool ShouldEmitCode => CSharpName != Bytes.CSharpName;
 
-    public override void WriteTo(Utf8JsonWriter writer, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
+    public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {
         if (!writtenSchemas.Add(SchemaName))
         {

--- a/src/AvroSourceGenerator/Schemas/LogicalSchema.cs
+++ b/src/AvroSourceGenerator/Schemas/LogicalSchema.cs
@@ -8,9 +8,9 @@ internal sealed record class LogicalSchema(
     SchemaName SchemaName)
     : AvroSchema(SchemaType.Logical, CSharpName, SchemaName, UnderlyingSchema.Properties)
 {
-    public override void WriteTo(Utf8JsonWriter writer, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
+    public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {
         var underlyingSchema = UnderlyingSchema with { Properties = Properties.Add("logicalType", JsonElement.Parse($"\"{SchemaName.Name}\"")) };
-        underlyingSchema.WriteTo(writer, writtenSchemas, containingNamespace);
+        underlyingSchema.WriteTo(writer, registeredSchemas, writtenSchemas, containingNamespace);
     }
 }

--- a/src/AvroSourceGenerator/Schemas/MapSchema.cs
+++ b/src/AvroSourceGenerator/Schemas/MapSchema.cs
@@ -6,12 +6,12 @@ namespace AvroSourceGenerator.Schemas;
 internal sealed record class MapSchema(AvroSchema ValueSchema, ImmutableSortedDictionary<string, JsonElement> Properties)
     : AvroSchema(SchemaType.Map, new CSharpName($"Dictionary<string, {ValueSchema}>", "System.Collections.Generic"), new SchemaName("map"), Properties)
 {
-    public override void WriteTo(Utf8JsonWriter writer, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
+    public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {
         writer.WriteStartObject();
         writer.WriteString("type", "map");
         writer.WritePropertyName("values");
-        ValueSchema.WriteTo(writer, writtenSchemas, containingNamespace);
+        ValueSchema.WriteTo(writer, registeredSchemas, writtenSchemas, containingNamespace);
         foreach (var entry in Properties)
         {
             writer.WritePropertyName(entry.Key);

--- a/src/AvroSourceGenerator/Schemas/PrimitiveSchema.cs
+++ b/src/AvroSourceGenerator/Schemas/PrimitiveSchema.cs
@@ -9,7 +9,7 @@ internal sealed record class PrimitiveSchema(SchemaType Type, CSharpName CSharpN
     public PrimitiveSchema(SchemaType type, CSharpName csharpName, SchemaName schemaName)
         : this(type, csharpName, schemaName, ImmutableSortedDictionary<string, JsonElement>.Empty) { }
 
-    public override void WriteTo(Utf8JsonWriter writer, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
+    public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {
         if (Properties.IsEmpty)
         {

--- a/src/AvroSourceGenerator/Schemas/ProtocolMessage.cs
+++ b/src/AvroSourceGenerator/Schemas/ProtocolMessage.cs
@@ -10,7 +10,7 @@ internal sealed record class ProtocolMessage(
     ProtocolResponse Response,
     ImmutableArray<AvroSchema> Errors)
 {
-    public void WriteTo(Utf8JsonWriter writer, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
+    public void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {
         writer.WriteStartObject();
         if (Documentation is not null)
@@ -22,18 +22,18 @@ internal sealed record class ProtocolMessage(
         writer.WriteStartArray();
         foreach (var parameter in RequestParameters)
         {
-            parameter.WriteTo(writer, writtenSchemas, containingNamespace);
+            parameter.WriteTo(writer, registeredSchemas, writtenSchemas, containingNamespace);
         }
 
         writer.WriteEndArray();
         writer.WritePropertyName("response");
-        Response.WriteTo(writer, writtenSchemas, containingNamespace);
+        Response.WriteTo(writer, registeredSchemas, writtenSchemas, containingNamespace);
         if (Errors.Length > 0)
         {
             writer.WriteStartArray("errors");
             foreach (var error in Errors)
             {
-                error.WriteTo(writer, writtenSchemas, containingNamespace);
+                error.WriteTo(writer, registeredSchemas, writtenSchemas, containingNamespace);
             }
 
             writer.WriteEndArray();

--- a/src/AvroSourceGenerator/Schemas/ProtocolRequestParameter.cs
+++ b/src/AvroSourceGenerator/Schemas/ProtocolRequestParameter.cs
@@ -11,12 +11,12 @@ internal sealed record class ProtocolRequestParameter(
     JsonElement? DefaultJson,
     object? Default)
 {
-    public void WriteTo(Utf8JsonWriter writer, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
+    public void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {
         writer.WriteStartObject();
         writer.WriteString("name", Name is ['@', ..] ? Name[1..] : Name);
         writer.WritePropertyName("type");
-        Type.WriteTo(writer, writtenSchemas, containingNamespace);
+        Type.WriteTo(writer, registeredSchemas, writtenSchemas, containingNamespace);
         if (Documentation is not null)
         {
             writer.WriteString("doc", Documentation);

--- a/src/AvroSourceGenerator/Schemas/ProtocolResponse.cs
+++ b/src/AvroSourceGenerator/Schemas/ProtocolResponse.cs
@@ -7,6 +7,6 @@ internal sealed record class ProtocolResponse(
     AvroSchema UnderlyingType,
     bool IsNullable)
 {
-    public void WriteTo(Utf8JsonWriter writer, HashSet<SchemaName> writtenSchemas, string? containingNamespace) =>
-        Type.WriteTo(writer, writtenSchemas, containingNamespace);
+    public void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace) =>
+        Type.WriteTo(writer, registeredSchemas, writtenSchemas, containingNamespace);
 }

--- a/src/AvroSourceGenerator/Schemas/ProtocolSchema.cs
+++ b/src/AvroSourceGenerator/Schemas/ProtocolSchema.cs
@@ -12,7 +12,7 @@ internal sealed record class ProtocolSchema(
     ImmutableSortedDictionary<string, JsonElement> Properties)
     : TopLevelSchema(SchemaType.Protocol, Json, SchemaName, Documentation, Properties)
 {
-    public override void WriteTo(Utf8JsonWriter writer, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
+    public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {
         writer.WriteStartObject();
         writer.WriteString("protocol", SchemaName.Name);
@@ -26,7 +26,7 @@ internal sealed record class ProtocolSchema(
             writer.WriteStartArray("types");
             foreach (var type in Types)
             {
-                type.WriteTo(writer, writtenSchemas, SchemaName.Namespace);
+                type.WriteTo(writer, registeredSchemas, writtenSchemas, SchemaName.Namespace);
             }
 
             writer.WriteEndArray();
@@ -38,7 +38,7 @@ internal sealed record class ProtocolSchema(
             foreach (var message in Messages)
             {
                 writer.WritePropertyName(message.MethodName is ['@', ..] ? message.MethodName[1..] : message.MethodName);
-                message.WriteTo(writer, writtenSchemas, SchemaName.Namespace);
+                message.WriteTo(writer, registeredSchemas, writtenSchemas, SchemaName.Namespace);
             }
 
             writer.WriteEndObject();

--- a/src/AvroSourceGenerator/Schemas/RecordSchema.cs
+++ b/src/AvroSourceGenerator/Schemas/RecordSchema.cs
@@ -14,7 +14,7 @@ internal sealed record class RecordSchema(
 {
     public AvroSchema? InheritsFrom { get; set; }
 
-    public override void WriteTo(Utf8JsonWriter writer, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
+    public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {
         if (!writtenSchemas.Add(SchemaName))
         {
@@ -41,7 +41,7 @@ internal sealed record class RecordSchema(
 
         writer.WriteStartArray("fields");
         foreach (var field in Fields)
-            field.WriteTo(writer, writtenSchemas, @namespace);
+            field.WriteTo(writer, writtenSchemas, registeredSchemas, @namespace);
         writer.WriteEndArray();
         foreach (var entry in Properties)
         {

--- a/src/AvroSourceGenerator/Schemas/SchemaType.cs
+++ b/src/AvroSourceGenerator/Schemas/SchemaType.cs
@@ -20,4 +20,5 @@ internal enum SchemaType
     Logical,
     Protocol,
     Variant,
+    Reference,
 }

--- a/src/AvroSourceGenerator/Schemas/UnionSchema.cs
+++ b/src/AvroSourceGenerator/Schemas/UnionSchema.cs
@@ -10,11 +10,11 @@ internal sealed record class UnionSchema(
     bool IsNullable)
     : AvroSchema(SchemaType.Union, CSharpName, new SchemaName(string.Empty), ImmutableSortedDictionary<string, JsonElement>.Empty)
 {
-    public override void WriteTo(Utf8JsonWriter writer, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
+    public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {
         writer.WriteStartArray();
         foreach (var schema in Schemas)
-            schema.WriteTo(writer, writtenSchemas, containingNamespace);
+            schema.WriteTo(writer, registeredSchemas, writtenSchemas, containingNamespace);
         writer.WriteEndArray();
     }
 

--- a/src/AvroSourceGenerator/Schemas/VariantSchema.cs
+++ b/src/AvroSourceGenerator/Schemas/VariantSchema.cs
@@ -24,7 +24,7 @@ internal sealed record class VariantSchema(
         return new SchemaName(new string(name), containingSchemaName.Namespace);
     }
 
-    public override void WriteTo(Utf8JsonWriter writer, HashSet<SchemaName> writtenSchemas, string? containingNamespace) { }
+    public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace) { }
 
     private static string GetDefaultDocumentation(ImmutableArray<AvroSchema> derivedSchemas)
     {


### PR DESCRIPTION
This will allow us to support references from fields to named schemas while the schemas are being defined. (Not in this PR)