### PR TITLE
Replace `JsonElement.Parse` with `JsonSerializer.SerializeToElement`

### DIFF
--- a/samples/AvroSourceGenerator.ApacheAvro/AvroSourceGenerator.ApacheAvro.csproj
+++ b/samples/AvroSourceGenerator.ApacheAvro/AvroSourceGenerator.ApacheAvro.csproj
@@ -2,12 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net48;net10.0</TargetFrameworks>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net48'">
-    <Nullable>disable</Nullable>
-    <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>
 
   <!--Required since we're referencing the generator through the csproj instead of the package -->

--- a/samples/AvroSourceGenerator.ApacheAvro/Program.cs
+++ b/samples/AvroSourceGenerator.ApacheAvro/Program.cs
@@ -1,36 +1,22 @@
-﻿// ReSharper disable RedundantUsingDirective
+﻿using com.example.finance;
 
-using System;
-using System.Collections.Generic;
-using com.example.finance;
-
-// ReSharper disable once ArrangeNamespaceBody
-namespace AvroSourceGenerator.ApacheAvro
+var transaction = new Transaction
 {
-    internal static class Program
+    id = Guid.NewGuid(),
+    amount = 123.45m,
+    currency = "USD",
+    timestamp = DateTime.UtcNow,
+    status = TransactionStatus.COMPLETED,
+    recipientId = "123456",
+    metadata = new Dictionary<string, string>
     {
-        private static void Main()
-        {
-            var transaction = new Transaction
-            {
-                id = Guid.NewGuid(),
-                amount = 123.45m,
-                currency = "USD",
-                timestamp = DateTime.UtcNow,
-                status = TransactionStatus.COMPLETED,
-                recipientId = "123456",
-                metadata = new Dictionary<string, string>
-                {
-                    { "key1", "value1" },
-                    { "key2", "value2" },
-                },
-                signature = new Signature(),
-                legacyId = "abc123",
-            };
+        { "key1", "value1" },
+        { "key2", "value2" },
+    },
+    signature = new Signature(),
+    legacyId = "abc123",
+};
 
-            new Random().NextBytes(transaction.signature.Value);
+new Random().NextBytes(transaction.signature.Value);
 
-            Console.WriteLine(transaction);
-        }
-    }
-}
+Console.WriteLine(transaction);

--- a/src/AvroSourceGenerator/AnalyzerReleases.Unshipped.md
+++ b/src/AvroSourceGenerator/AnalyzerReleases.Unshipped.md
@@ -10,3 +10,4 @@ AVROSG0002  | Compiler      | Error    | Invalid schema logic
 AVROSG0003  | Configuration | Warning  | No Avro library detected
 AVROSG0004  | Configuration | Warning  | Multiple Avro libraries detected
 AVROSG0005  | Compiler      | Error    | Duplicate Avro schema
+AVROSG9999  | Compiler      | Error    | Unknown generator error

--- a/src/AvroSourceGenerator/Diagnostics/UnknownErrorDiagnostic.cs
+++ b/src/AvroSourceGenerator/Diagnostics/UnknownErrorDiagnostic.cs
@@ -1,0 +1,18 @@
+﻿using AvroSourceGenerator.Parsing;
+using Microsoft.CodeAnalysis;
+
+namespace AvroSourceGenerator.Diagnostics;
+
+internal static class UnknownErrorDiagnostic
+{
+    private static readonly DiagnosticDescriptor s_descriptor = new(
+        id: "AVROSG9999",
+        title: "Unknown error in Avro Source Generator",
+        messageFormat: "An unknown error occurred in Avro Source Generator: {0}",
+        category: "Compiler",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "An unexpected error occurred during the execution of the Avro Source Generator. Please report this issue with details about how to reproduce it.");
+
+    public static DiagnosticInfo Create(LocationInfo location, string errorMessage) => new(s_descriptor, location, errorMessage);
+}

--- a/src/AvroSourceGenerator/Emit/AvroTemplate.cs
+++ b/src/AvroSourceGenerator/Emit/AvroTemplate.cs
@@ -44,8 +44,17 @@ internal static class AvroTemplate
 
     private static string GetSchemaJson(TopLevelSchema schema, ImmutableDictionary<SchemaName, TopLevelSchema> registeredSchemas, RenderSettings settings)
     {
+        if (settings.AvroLibrary is not AvroLibrary.Apache)
+        {
+            return string.Empty;
+        }
+
         return (settings.LanguageFeatures & LanguageFeatures.RawStringLiterals) != 0
-            ? string.Join("\n", "\"\"\"", schema.ToJsonString(registeredSchemas, new JsonWriterOptions { Indented = true }), "\"\"\"")
+            ? $""""
+            """
+            {schema.ToJsonString(registeredSchemas, new JsonWriterOptions { Indented = true })}
+            """
+            """"
             : StringFunctions.Literal(schema.ToJsonString(registeredSchemas));
     }
 }

--- a/src/AvroSourceGenerator/Emit/Renderer.cs
+++ b/src/AvroSourceGenerator/Emit/Renderer.cs
@@ -42,6 +42,10 @@ internal static class Renderer
             // TODO: We can probably get a better location for the error.
             diagnostics = diagnostics.Add(InvalidSchemaDiagnostic.Create(LocationInfo.FromSourceFile(avroFile.Path, avroFile.Text), ex.Message));
         }
+        catch (Exception ex)
+        {
+            diagnostics = diagnostics.Add(UnknownErrorDiagnostic.Create(LocationInfo.FromSourceFile(avroFile.Path, avroFile.Text), ex.Message));
+        }
 
         return new RenderResult([], diagnostics);
     }

--- a/src/AvroSourceGenerator/Schemas/LogicalSchema.cs
+++ b/src/AvroSourceGenerator/Schemas/LogicalSchema.cs
@@ -10,7 +10,8 @@ internal sealed record class LogicalSchema(
 {
     public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {
-        var underlyingSchema = UnderlyingSchema with { Properties = Properties.Add("logicalType", JsonElement.Parse($"\"{SchemaName.Name}\"")) };
+        var logicalType = JsonSerializer.SerializeToElement(SchemaName.Name);
+        var underlyingSchema = UnderlyingSchema with { Properties = Properties.Add("logicalType", logicalType) };
         underlyingSchema.WriteTo(writer, registeredSchemas, writtenSchemas, containingNamespace);
     }
 }

--- a/src/AvroSourceGenerator/Templates/schema.sbncs
+++ b/src/AvroSourceGenerator/Templates/schema.sbncs
@@ -20,13 +20,13 @@ namespace {{ Schema.CSharpName.Namespace }}
         when 'Enum'
             include 'enum' schema: Schema
         when 'Fixed'
-            include 'fixed' schema: Schema schemaJson: SchemaJson
+            include 'fixed' schema: Schema
         when 'Record'
-            include 'record' schema: Schema schemaJson: SchemaJson
+            include 'record' schema: Schema
         when 'Error'
-            include 'error' schema: Schema schemaJson: SchemaJson
+            include 'error' schema: Schema
         when 'Protocol'
-            include 'protocol' schema: Schema schemaJson: SchemaJson
+            include 'protocol' schema: Schema
         when 'Variant'
             include 'variant' schema: Schema
         end


### PR DESCRIPTION
The first is not supported and causes the source generator to stop working.

Also, added a general catch at the end of source generation to make sure we emit a diagnostic for unknown errors.