### PR TITLE
Extract SchemaRegistry reserved property lookup

### DIFF
--- a/src/AvroSourceGenerator.Core/Registry/ReservedProperties.cs
+++ b/src/AvroSourceGenerator.Core/Registry/ReservedProperties.cs
@@ -2,7 +2,7 @@ using AvroSourceGenerator.Schemas;
 
 namespace AvroSourceGenerator.Registry;
 
-internal static class SchemaRegistryReservedProperties
+internal static class ReservedProperties
 {
     private static readonly HashSet<string> s_reservedProperties =
     [

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.cs
@@ -124,7 +124,7 @@ public readonly partial struct SchemaRegistry(TargetProfile targetProfile, bool 
     {
         var properties = ImmutableSortedDictionary.CreateBuilder<string, JsonElement>();
         foreach (var property in schema.EnumerateObject()
-            .Where(property => !SchemaRegistryReservedProperties.IsReserved(property.Name)))
+            .Where(property => !ReservedProperties.IsReserved(property.Name)))
         {
             properties.Add(property.Name, property.Value);
         }

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
@@ -16,22 +16,6 @@ public readonly partial struct SchemaRegistry(TargetProfile targetProfile, bool 
     private readonly Dictionary<SchemaName, TopLevelSchema> _schemas = [];
     private readonly List<SchemaName> _recursionStack = [];
 
-    private static readonly HashSet<string> s_reservedProperties =
-    [
-        AvroJsonKeys.Type,
-        AvroJsonKeys.Name,
-        AvroJsonKeys.Namespace,
-        AvroJsonKeys.Fields,
-        AvroJsonKeys.Items,
-        AvroJsonKeys.Size,
-        AvroJsonKeys.Symbols,
-        AvroJsonKeys.Values,
-        AvroJsonKeys.Aliases,
-        AvroJsonKeys.Order,
-        AvroJsonKeys.Doc,
-        AvroJsonKeys.Default,
-        AvroJsonKeys.LogicalType,
-    ];
 
     public int Count => _schemas.Count;
 
@@ -140,7 +124,7 @@ public readonly partial struct SchemaRegistry(TargetProfile targetProfile, bool 
     {
         var properties = ImmutableSortedDictionary.CreateBuilder<string, JsonElement>();
         foreach (var property in schema.EnumerateObject()
-            .Where(property => !s_reservedProperties.Contains(property.Name)))
+            .Where(property => !SchemaRegistryReservedProperties.IsReserved(property.Name)))
         {
             properties.Add(property.Name, property.Value);
         }

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistryReservedProperties.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistryReservedProperties.cs
@@ -1,0 +1,25 @@
+using AvroSourceGenerator.Schemas;
+
+namespace AvroSourceGenerator.Registry;
+
+internal static class SchemaRegistryReservedProperties
+{
+    private static readonly HashSet<string> s_reservedProperties =
+    [
+        AvroJsonKeys.Type,
+        AvroJsonKeys.Name,
+        AvroJsonKeys.Namespace,
+        AvroJsonKeys.Fields,
+        AvroJsonKeys.Items,
+        AvroJsonKeys.Size,
+        AvroJsonKeys.Symbols,
+        AvroJsonKeys.Values,
+        AvroJsonKeys.Aliases,
+        AvroJsonKeys.Order,
+        AvroJsonKeys.Doc,
+        AvroJsonKeys.Default,
+        AvroJsonKeys.LogicalType,
+    ];
+
+    public static bool IsReserved(string propertyName) => s_reservedProperties.Contains(propertyName);
+}


### PR DESCRIPTION
## Summary
- extract reserved property names from SchemaRegistry into SchemaRegistryReservedProperties
- expose IsReserved and use it in GetProperties
- keep behavior unchanged while centralizing reserved-key checks

## Validation
- dotnet test tests/AvroSourceGenerator.Tests/AvroSourceGenerator.Tests.csproj --filter SchemaRegistryReservedPropertiesTests
- dotnet test tests/AvroSourceGenerator.Tests/AvroSourceGenerator.Tests.csproj