### PR TITLE
Move protocol classes to root Protocols namespace in Core

### DIFF
--- a/src/AvroSourceGenerator.Core/Protocols/ProtocolMessage.cs
+++ b/src/AvroSourceGenerator.Core/Protocols/ProtocolMessage.cs
@@ -43,4 +43,3 @@ public sealed record class ProtocolMessage(
         writer.WriteEndObject();
     }
 }
-

--- a/src/AvroSourceGenerator.Core/Protocols/ProtocolMessage.cs
+++ b/src/AvroSourceGenerator.Core/Protocols/ProtocolMessage.cs
@@ -1,7 +1,8 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using System.Text.Json;
+using AvroSourceGenerator.Schemas;
 
-namespace AvroSourceGenerator.Schemas;
+namespace AvroSourceGenerator.Protocols;
 
 public sealed record class ProtocolMessage(
     string MethodName,
@@ -42,3 +43,4 @@ public sealed record class ProtocolMessage(
         writer.WriteEndObject();
     }
 }
+

--- a/src/AvroSourceGenerator.Core/Protocols/ProtocolRequestParameter.cs
+++ b/src/AvroSourceGenerator.Core/Protocols/ProtocolRequestParameter.cs
@@ -32,4 +32,3 @@ public sealed record class ProtocolRequestParameter(
         writer.WriteEndObject();
     }
 }
-

--- a/src/AvroSourceGenerator.Core/Protocols/ProtocolRequestParameter.cs
+++ b/src/AvroSourceGenerator.Core/Protocols/ProtocolRequestParameter.cs
@@ -1,6 +1,7 @@
-﻿using System.Text.Json;
+using System.Text.Json;
+using AvroSourceGenerator.Schemas;
 
-namespace AvroSourceGenerator.Schemas;
+namespace AvroSourceGenerator.Protocols;
 
 public sealed record class ProtocolRequestParameter(
     string Name,
@@ -31,3 +32,4 @@ public sealed record class ProtocolRequestParameter(
         writer.WriteEndObject();
     }
 }
+

--- a/src/AvroSourceGenerator.Core/Protocols/ProtocolResponse.cs
+++ b/src/AvroSourceGenerator.Core/Protocols/ProtocolResponse.cs
@@ -1,6 +1,7 @@
-﻿using System.Text.Json;
+using System.Text.Json;
+using AvroSourceGenerator.Schemas;
 
-namespace AvroSourceGenerator.Schemas;
+namespace AvroSourceGenerator.Protocols;
 
 public sealed record class ProtocolResponse(
     AvroSchema Type,
@@ -10,3 +11,4 @@ public sealed record class ProtocolResponse(
     public void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace) =>
         Type.WriteTo(writer, registeredSchemas, writtenSchemas, containingNamespace);
 }
+

--- a/src/AvroSourceGenerator.Core/Protocols/ProtocolResponse.cs
+++ b/src/AvroSourceGenerator.Core/Protocols/ProtocolResponse.cs
@@ -11,4 +11,3 @@ public sealed record class ProtocolResponse(
     public void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace) =>
         Type.WriteTo(writer, registeredSchemas, writtenSchemas, containingNamespace);
 }
-

--- a/src/AvroSourceGenerator.Core/Protocols/ProtocolSchema.cs
+++ b/src/AvroSourceGenerator.Core/Protocols/ProtocolSchema.cs
@@ -59,4 +59,3 @@ public sealed record class ProtocolSchema(
         writer.WriteEndObject();
     }
 }
-

--- a/src/AvroSourceGenerator.Core/Protocols/ProtocolSchema.cs
+++ b/src/AvroSourceGenerator.Core/Protocols/ProtocolSchema.cs
@@ -1,7 +1,8 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using System.Text.Json;
+using AvroSourceGenerator.Schemas;
 
-namespace AvroSourceGenerator.Schemas;
+namespace AvroSourceGenerator.Protocols;
 
 public sealed record class ProtocolSchema(
     JsonElement Json,
@@ -58,3 +59,4 @@ public sealed record class ProtocolSchema(
         writer.WriteEndObject();
     }
 }
+

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Protocol.Messages.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Protocol.Messages.cs
@@ -26,4 +26,3 @@ public readonly partial struct SchemaRegistry
         return new ProtocolMessage(methodName, documentation, requestParameters, response, errors);
     }
 }
-

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Protocol.Messages.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Protocol.Messages.cs
@@ -1,6 +1,7 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using System.Text.Json;
 using AvroSourceGenerator.Extensions;
+using AvroSourceGenerator.Protocols;
 using AvroSourceGenerator.Schemas;
 
 namespace AvroSourceGenerator.Registry;
@@ -25,3 +26,4 @@ public readonly partial struct SchemaRegistry
         return new ProtocolMessage(methodName, documentation, requestParameters, response, errors);
     }
 }
+

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Protocol.RequestParameters.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Protocol.RequestParameters.cs
@@ -35,4 +35,3 @@ public readonly partial struct SchemaRegistry
         return new ProtocolRequestParameter(name, type, underlyingType, isNullable, documentation, defaultJson, @default);
     }
 }
-

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Protocol.RequestParameters.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Protocol.RequestParameters.cs
@@ -1,6 +1,7 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using System.Text.Json;
 using AvroSourceGenerator.Extensions;
+using AvroSourceGenerator.Protocols;
 using AvroSourceGenerator.Schemas;
 
 namespace AvroSourceGenerator.Registry;
@@ -34,3 +35,4 @@ public readonly partial struct SchemaRegistry
         return new ProtocolRequestParameter(name, type, underlyingType, isNullable, documentation, defaultJson, @default);
     }
 }
+

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Protocol.Response.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Protocol.Response.cs
@@ -20,4 +20,3 @@ public readonly partial struct SchemaRegistry
         return new ProtocolResponse(type, underlyingType, isNullable);
     }
 }
-

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Protocol.Response.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Protocol.Response.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using AvroSourceGenerator.Protocols;
 using AvroSourceGenerator.Schemas;
 
 namespace AvroSourceGenerator.Registry;
@@ -19,3 +20,4 @@ public readonly partial struct SchemaRegistry
         return new ProtocolResponse(type, underlyingType, isNullable);
     }
 }
+

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Protocol.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Protocol.cs
@@ -28,4 +28,3 @@ public readonly partial struct SchemaRegistry
         }
     }
 }
-

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Protocol.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Protocol.cs
@@ -1,6 +1,7 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using System.Text.Json;
 using AvroSourceGenerator.Extensions;
+using AvroSourceGenerator.Protocols;
 using AvroSourceGenerator.Schemas;
 
 namespace AvroSourceGenerator.Registry;
@@ -27,3 +28,4 @@ public readonly partial struct SchemaRegistry
         }
     }
 }
+

--- a/tests/AvroSourceGenerator.Tests/SchemaRegistryReservedPropertiesTests.cs
+++ b/tests/AvroSourceGenerator.Tests/SchemaRegistryReservedPropertiesTests.cs
@@ -1,6 +1,7 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using AvroSourceGenerator.Configuration;
 using AvroSourceGenerator.Registry;
+using AvroSourceGenerator.Protocols;
 using AvroSourceGenerator.Schemas;
 
 namespace AvroSourceGenerator.Tests;
@@ -72,3 +73,4 @@ public sealed class SchemaRegistryReservedPropertiesTests
         return document.RootElement.Clone();
     }
 }
+

--- a/tests/AvroSourceGenerator.Tests/SchemaRegistryReservedPropertiesTests.cs
+++ b/tests/AvroSourceGenerator.Tests/SchemaRegistryReservedPropertiesTests.cs
@@ -73,4 +73,3 @@ public sealed class SchemaRegistryReservedPropertiesTests
         return document.RootElement.Clone();
     }
 }
-


### PR DESCRIPTION
## Summary
- move protocol-related classes from Schemas to a new root Protocols folder in AvroSourceGenerator.Core
- change protocol class namespaces from AvroSourceGenerator.Schemas to AvroSourceGenerator.Protocols
- update all affected usings in core registry files and tests
- remove trailing blank lines introduced in touched files

## Validation
- dotnet build avro-source-generator.slnx -v minimal