### PR TITLE
Move ShouldEmitCode logic into AvroTemplate

### DIFF
--- a/src/AvroSourceGenerator.Core/Schemas/FixedSchema.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/FixedSchema.cs
@@ -26,8 +26,6 @@ public sealed record class FixedSchema(
         };
     }
 
-    public override bool ShouldEmitCode => CSharpName != Bytes.CSharpName;
-
     public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {
         if (!writtenSchemas.Add(SchemaName))

--- a/src/AvroSourceGenerator.Core/Schemas/TopLevelSchema.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/TopLevelSchema.cs
@@ -9,7 +9,4 @@ public abstract record class TopLevelSchema(
     SchemaName SchemaName,
     string? Documentation,
     ImmutableSortedDictionary<string, JsonElement> Properties)
-    : AvroSchema(Type, CSharpName.FromSchemaName(SchemaName), SchemaName, Properties)
-{
-    public virtual bool ShouldEmitCode => true;
-}
+    : AvroSchema(Type, CSharpName.FromSchemaName(SchemaName), SchemaName, Properties);

--- a/src/AvroSourceGenerator/Emit/AvroTemplate.cs
+++ b/src/AvroSourceGenerator/Emit/AvroTemplate.cs
@@ -31,7 +31,7 @@ internal static class AvroTemplate
 
         return
         [
-            .. schemaRegistry.Where(schema => schema.ShouldEmitCode).Select(schema =>
+            .. schemaRegistry.Where(ShouldEmitCode).Select(schema =>
             {
                 templateContext.SetValue(new ScriptVariableGlobal("Schema"), schema);
                 templateContext.SetValue(new ScriptVariableGlobal("SchemaJson"), GetSchemaJson(schema, registeredSchemas, settings));
@@ -40,6 +40,11 @@ internal static class AvroTemplate
                 return new RenderedSchema(hintName, sourceText);
             })
         ];
+    }
+
+    private static bool ShouldEmitCode(TopLevelSchema schema)
+    {
+        return schema is not FixedSchema fixedSchema || fixedSchema.CSharpName != AvroSchema.Bytes.CSharpName;
     }
 
     private static string GetSchemaJson(TopLevelSchema schema, ImmutableDictionary<SchemaName, TopLevelSchema> registeredSchemas, RenderSettings settings)


### PR DESCRIPTION
## Summary
- remove ShouldEmitCode from TopLevelSchema
- remove the FixedSchema override of ShouldEmitCode
- add a private ShouldEmitCode(TopLevelSchema) helper in AvroTemplate and use it at the only call site

## Notes
- behavior is preserved: fixed schemas mapped to yte[] are still excluded from code emission