### PR TITLE
Refactor property extraction and clarify recursion scope naming

### DIFF
--- a/src/AvroSourceGenerator.Core/Extensions/JsonElementAvroExtensions.cs
+++ b/src/AvroSourceGenerator.Core/Extensions/JsonElementAvroExtensions.cs
@@ -88,5 +88,30 @@ public static class JsonElementAvroExtensions
                 ? size
                 : throw new InvalidSchemaException($"'{AvroJsonKeys.Size}' property must be a positive integer (found '{json}') in schema: {schema.GetRawText()}");
         }
+
+
+        public ImmutableSortedDictionary<string, JsonElement> GetSchemaProperties()
+        {
+            var properties = ImmutableSortedDictionary.CreateBuilder<string, JsonElement>();
+            foreach (var property in schema.EnumerateObject()
+                .Where(property => !ReservedSchemaProperties.IsReserved(property.Name)))
+            {
+                properties.Add(property.Name, property.Value);
+            }
+
+            return properties.ToImmutable();
+        }
+
+        public ImmutableSortedDictionary<string, JsonElement> GetProtocolProperties()
+        {
+            var properties = ImmutableSortedDictionary.CreateBuilder<string, JsonElement>();
+            foreach (var property in schema.EnumerateObject()
+                .Where(property => !ReservedProtocolProperties.IsReserved(property.Name)))
+            {
+                properties.Add(property.Name, property.Value);
+            }
+
+            return properties.ToImmutable();
+        }
     }
 }

--- a/src/AvroSourceGenerator.Core/Extensions/ReservedProtocolProperties.cs
+++ b/src/AvroSourceGenerator.Core/Extensions/ReservedProtocolProperties.cs
@@ -1,6 +1,6 @@
 ﻿using AvroSourceGenerator.Schemas;
 
-namespace AvroSourceGenerator.Registry;
+namespace AvroSourceGenerator.Extensions;
 
 internal static class ReservedProtocolProperties
 {

--- a/src/AvroSourceGenerator.Core/Extensions/ReservedSchemaProperties.cs
+++ b/src/AvroSourceGenerator.Core/Extensions/ReservedSchemaProperties.cs
@@ -1,6 +1,6 @@
 ﻿using AvroSourceGenerator.Schemas;
 
-namespace AvroSourceGenerator.Registry;
+namespace AvroSourceGenerator.Extensions;
 
 internal static class ReservedSchemaProperties
 {

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Protocol.Types.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Protocol.Types.cs
@@ -22,10 +22,10 @@ public readonly partial struct SchemaRegistry
 
         return type switch
         {
-            AvroTypeNames.Enum => Enum(schema, containingNamespace, GetSchemaProperties(schema)),
-            AvroTypeNames.Record => Record(schema, containingNamespace, GetSchemaProperties(schema)),
-            AvroTypeNames.Error => Error(schema, containingNamespace, GetSchemaProperties(schema)),
-            AvroTypeNames.Fixed => Fixed(schema, containingNamespace, GetSchemaProperties(schema)),
+            AvroTypeNames.Enum => Enum(schema, containingNamespace),
+            AvroTypeNames.Record => Record(schema, containingNamespace),
+            AvroTypeNames.Error => Error(schema, containingNamespace),
+            AvroTypeNames.Fixed => Fixed(schema, containingNamespace),
             _ => throw new InvalidSchemaException($"Unknown schema type '{type}' in {schema.GetRawText()}")
         };
     }

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Protocol.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Protocol.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using System.Text.Json;
 using AvroSourceGenerator.Extensions;
 using AvroSourceGenerator.Protocols;
@@ -8,18 +7,19 @@ namespace AvroSourceGenerator.Registry;
 
 public readonly partial struct SchemaRegistry
 {
-    private ProtocolSchema Protocol(JsonElement schema, string? containingNamespace, ImmutableSortedDictionary<string, JsonElement> properties)
+    private ProtocolSchema Protocol(JsonElement schema, string? containingNamespace)
     {
         var schemaName = schema.GetRequiredProtocolName(containingNamespace);
 
         if (_schemas.ContainsKey(schemaName))
             throw new InvalidSchemaException($"Redeclaration of schema '{schemaName}'");
 
-        using (Track(schemaName))
+        using (EnterRecursionScope(schemaName))
         {
             var documentation = schema.GetDocumentation();
             var types = ProtocolTypes(schema.GetRequiredArray(AvroJsonKeys.Types), schemaName.Namespace);
             var messages = ProtocolMessages(schema.GetRequiredObject(AvroJsonKeys.Messages), schemaName.Namespace);
+            var properties = schema.GetProtocolProperties();
 
             var protocolSchema = new ProtocolSchema(schema, schemaName, documentation, types, messages, properties);
             _schemas[schemaName] = protocolSchema;

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Array.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Array.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Immutable;
-using System.Text.Json;
+﻿using System.Text.Json;
 using AvroSourceGenerator.Extensions;
 using AvroSourceGenerator.Schemas;
 
@@ -7,12 +6,14 @@ namespace AvroSourceGenerator.Registry;
 
 public readonly partial struct SchemaRegistry
 {
-    private ArraySchema Array(JsonElement schema, string? containingNamespace, ImmutableSortedDictionary<string, JsonElement> properties)
+    private ArraySchema Array(JsonElement schema, string? containingNamespace)
     {
         var itemsSchema = schema.GetRequiredProperty(AvroJsonKeys.Items);
 
         var items = Schema(itemsSchema, containingNamespace);
+        var documentation = schema.GetDocumentation();
+        var properties = schema.GetSchemaProperties();
 
-        return new ArraySchema(items, properties);
+        return new ArraySchema(items, documentation, properties);
     }
 }

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Enum.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Enum.cs
@@ -1,4 +1,3 @@
-﻿using System.Collections.Immutable;
 using System.Text.Json;
 using AvroSourceGenerator.Extensions;
 using AvroSourceGenerator.Schemas;
@@ -7,19 +6,20 @@ namespace AvroSourceGenerator.Registry;
 
 public readonly partial struct SchemaRegistry
 {
-    private EnumSchema Enum(JsonElement schema, string? containingNamespace, ImmutableSortedDictionary<string, JsonElement> properties)
+    private EnumSchema Enum(JsonElement schema, string? containingNamespace)
     {
         var schemaName = schema.GetRequiredSchemaName(containingNamespace);
 
         if (_schemas.ContainsKey(schemaName))
             throw new InvalidSchemaException($"Redeclaration of schema '{schemaName}'");
 
-        using (Track(schemaName))
+        using (EnterRecursionScope(schemaName))
         {
             var documentation = schema.GetDocumentation();
             var aliases = schema.GetAliases();
             var symbols = schema.GetSymbols();
             var @default = schema.GetNullableString(AvroJsonKeys.Default);
+            var properties = schema.GetSchemaProperties();
 
             var enumSchema = new EnumSchema(schema, schemaName, documentation, aliases, symbols, @default, properties);
             _schemas[schemaName] = enumSchema;

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Error.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Error.cs
@@ -1,4 +1,3 @@
-﻿using System.Collections.Immutable;
 using System.Text.Json;
 using AvroSourceGenerator.Extensions;
 using AvroSourceGenerator.Schemas;
@@ -7,18 +6,19 @@ namespace AvroSourceGenerator.Registry;
 
 public readonly partial struct SchemaRegistry
 {
-    private ErrorSchema Error(JsonElement schema, string? containingNamespace, ImmutableSortedDictionary<string, JsonElement> properties)
+    private ErrorSchema Error(JsonElement schema, string? containingNamespace)
     {
         var schemaName = schema.GetRequiredSchemaName(containingNamespace);
 
         if (_schemas.ContainsKey(schemaName))
             throw new InvalidSchemaException($"Redeclaration of schema '{schemaName}'");
 
-        using (Track(schemaName))
+        using (EnterRecursionScope(schemaName))
         {
             var documentation = schema.GetDocumentation();
             var aliases = schema.GetAliases();
             var fields = Fields(schema, schemaName);
+            var properties = schema.GetSchemaProperties();
 
             var errorSchema = new ErrorSchema(schema, schemaName, documentation, aliases, fields, properties);
             _schemas[schemaName] = errorSchema;

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Fields.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Fields.cs
@@ -56,7 +56,7 @@ public readonly partial struct SchemaRegistry
         var defaultJson = field.GetNullableProperty(AvroJsonKeys.Default);
         var @default = GetValue(type, defaultJson);
         var order = field.GetNullableInt32(AvroJsonKeys.Order);
-        var properties = GetSchemaProperties(field);
+        var properties = field.GetSchemaProperties();
 
         return new Field(name, type, underlyingType, isNullable, documentation, aliases, defaultJson, @default, order, properties, remarks);
     }

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Fixed.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Fixed.cs
@@ -1,4 +1,3 @@
-﻿using System.Collections.Immutable;
 using System.Text.Json;
 using AvroSourceGenerator.Configuration;
 using AvroSourceGenerator.Extensions;
@@ -8,18 +7,19 @@ namespace AvroSourceGenerator.Registry;
 
 public readonly partial struct SchemaRegistry
 {
-    private FixedSchema Fixed(JsonElement schema, string? containingNamespace, ImmutableSortedDictionary<string, JsonElement> properties)
+    private FixedSchema Fixed(JsonElement schema, string? containingNamespace)
     {
         var schemaName = schema.GetRequiredSchemaName(containingNamespace);
 
         if (_schemas.ContainsKey(schemaName))
             throw new InvalidSchemaException($"Redeclaration of schema '{schemaName}'");
 
-        using (Track(schemaName))
+        using (EnterRecursionScope(schemaName))
         {
             var documentation = schema.GetDocumentation();
             var aliases = schema.GetAliases();
             var size = schema.GetFixedSize();
+            var properties = schema.GetSchemaProperties();
 
             var fixedSchema = targetProfile switch
             {

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Map.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Map.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Immutable;
-using System.Text.Json;
+﻿using System.Text.Json;
 using AvroSourceGenerator.Extensions;
 using AvroSourceGenerator.Schemas;
 
@@ -7,15 +6,14 @@ namespace AvroSourceGenerator.Registry;
 
 public readonly partial struct SchemaRegistry
 {
-    private MapSchema Map(
-        JsonElement schema,
-        string? containingNamespace,
-        ImmutableSortedDictionary<string, JsonElement> properties)
+    private MapSchema Map(JsonElement schema, string? containingNamespace)
     {
         var valuesSchema = schema.GetRequiredProperty(AvroJsonKeys.Values);
 
         var values = Schema(valuesSchema, containingNamespace);
+        var documentation = schema.GetDocumentation();
+        var properties = schema.GetSchemaProperties();
 
-        return new MapSchema(values, properties);
+        return new MapSchema(values, documentation, properties);
     }
 }

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Record.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Record.cs
@@ -1,4 +1,3 @@
-﻿using System.Collections.Immutable;
 using System.Text.Json;
 using AvroSourceGenerator.Extensions;
 using AvroSourceGenerator.Schemas;
@@ -7,21 +6,19 @@ namespace AvroSourceGenerator.Registry;
 
 public readonly partial struct SchemaRegistry
 {
-    private RecordSchema Record(
-        JsonElement schema,
-        string? containingNamespace,
-        ImmutableSortedDictionary<string, JsonElement> properties)
+    private RecordSchema Record(JsonElement schema, string? containingNamespace)
     {
         var schemaName = schema.GetRequiredSchemaName(containingNamespace);
 
         if (_schemas.ContainsKey(schemaName))
             throw new InvalidSchemaException($"Redeclaration of schema '{schemaName}'");
 
-        using (Track(schemaName))
+        using (EnterRecursionScope(schemaName))
         {
             var documentation = schema.GetDocumentation();
             var aliases = schema.GetAliases();
             var fields = Fields(schema, schemaName);
+            var properties = schema.GetSchemaProperties();
 
             var recordSchema = new RecordSchema(schema, schemaName, documentation, aliases, fields, properties);
 

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Immutable;
+using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Text.Json;
@@ -63,7 +62,7 @@ public readonly partial struct SchemaRegistry(TargetProfile targetProfile, bool 
         return null;
     }
 
-    private RecursionScope Track(SchemaName schemaName) => new(_recursionStack, schemaName);
+    private RecursionScope EnterRecursionScope(SchemaName schemaName) => new(_recursionStack, schemaName);
 
     private AvroSchema Schema(JsonElement schema, string? containingNamespace)
     {
@@ -87,25 +86,25 @@ public readonly partial struct SchemaRegistry(TargetProfile targetProfile, bool 
     {
         if (schema.TryGetProperty(AvroJsonKeys.Protocol, out _))
         {
-            return Protocol(schema, containingNamespace, GetProtocolProperties(schema));
+            return Protocol(schema, containingNamespace);
         }
 
-        var underlyingSchema = UnderlyingSchema(schema, containingNamespace, GetSchemaProperties(schema));
+        var underlyingSchema = UnderlyingSchema(schema, containingNamespace);
 
         return schema.TryGetProperty(AvroJsonKeys.LogicalType, out _) ? Logical(schema, underlyingSchema) : underlyingSchema;
     }
 
-    private AvroSchema UnderlyingSchema(JsonElement schema, string? containingNamespace, ImmutableSortedDictionary<string, JsonElement> properties)
+    private AvroSchema UnderlyingSchema(JsonElement schema, string? containingNamespace)
     {
         var type = schema.GetSchemaType();
         switch (type)
         {
-            case AvroTypeNames.Array: return Array(schema, containingNamespace, properties);
-            case AvroTypeNames.Map: return Map(schema, containingNamespace, properties);
-            case AvroTypeNames.Enum: return Enum(schema, containingNamespace, properties);
-            case AvroTypeNames.Record: return Record(schema, containingNamespace, properties);
-            case AvroTypeNames.Error: return Error(schema, containingNamespace, properties);
-            case AvroTypeNames.Fixed: return Fixed(schema, containingNamespace, properties);
+            case AvroTypeNames.Array: return Array(schema, containingNamespace);
+            case AvroTypeNames.Map: return Map(schema, containingNamespace);
+            case AvroTypeNames.Enum: return Enum(schema, containingNamespace);
+            case AvroTypeNames.Record: return Record(schema, containingNamespace);
+            case AvroTypeNames.Error: return Error(schema, containingNamespace);
+            case AvroTypeNames.Fixed: return Fixed(schema, containingNamespace);
         }
 
         var wellKnown = FindByName(type, containingNamespace)
@@ -113,35 +112,15 @@ public readonly partial struct SchemaRegistry(TargetProfile targetProfile, bool 
 
         if (wellKnown is PrimitiveSchema primitive)
         {
-            return primitive with { Properties = properties };
+            return primitive with
+            {
+                Documentation = schema.GetDocumentation(),
+                Properties = schema.GetSchemaProperties(),
+            };
         }
 
         // TODO: Should we add/merge properties for other schema types?
         return wellKnown;
-    }
-
-    private static ImmutableSortedDictionary<string, JsonElement> GetSchemaProperties(JsonElement schema)
-    {
-        var properties = ImmutableSortedDictionary.CreateBuilder<string, JsonElement>();
-        foreach (var property in schema.EnumerateObject()
-            .Where(property => !ReservedSchemaProperties.IsReserved(property.Name)))
-        {
-            properties.Add(property.Name, property.Value);
-        }
-
-        return properties.ToImmutable();
-    }
-
-    private static ImmutableSortedDictionary<string, JsonElement> GetProtocolProperties(JsonElement schema)
-    {
-        var properties = ImmutableSortedDictionary.CreateBuilder<string, JsonElement>();
-        foreach (var property in schema.EnumerateObject()
-            .Where(property => !ReservedProtocolProperties.IsReserved(property.Name)))
-        {
-            properties.Add(property.Name, property.Value);
-        }
-
-        return properties.ToImmutable();
     }
 
     private string? GetValue(AvroSchema type, JsonElement? json)

--- a/src/AvroSourceGenerator.Core/Schemas/ArraySchema.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/ArraySchema.cs
@@ -3,8 +3,8 @@ using System.Text.Json;
 
 namespace AvroSourceGenerator.Schemas;
 
-public sealed record class ArraySchema(AvroSchema ItemSchema, ImmutableSortedDictionary<string, JsonElement> Properties)
-    : AvroSchema(SchemaType.Array, new CSharpName($"List<{ItemSchema}>", "System.Collections.Generic"), new SchemaName(AvroTypeNames.Array), Properties)
+public sealed record class ArraySchema(AvroSchema ItemSchema, string? Documentation, ImmutableSortedDictionary<string, JsonElement> Properties)
+    : AvroSchema(SchemaType.Array, GetCSharpName(ItemSchema), new SchemaName(AvroTypeNames.Array), Documentation, Properties)
 {
     public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {
@@ -20,4 +20,6 @@ public sealed record class ArraySchema(AvroSchema ItemSchema, ImmutableSortedDic
 
         writer.WriteEndObject();
     }
+
+    private static CSharpName GetCSharpName(AvroSchema itemSchema) => new($"List<{itemSchema}>", "System.Collections.Generic");
 }

--- a/src/AvroSourceGenerator.Core/Schemas/AvroSchema.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/AvroSchema.cs
@@ -8,6 +8,7 @@ public abstract record class AvroSchema(
     SchemaType Type,
     CSharpName CSharpName,
     SchemaName SchemaName,
+    string? Documentation,
     ImmutableSortedDictionary<string, JsonElement> Properties)
 {
     // ReSharper disable once UnusedMember.Global
@@ -26,12 +27,12 @@ public abstract record class AvroSchema(
 
     public abstract void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace);
 
-    public static readonly PrimitiveSchema Object = new PrimitiveSchema(SchemaType.Null, new CSharpName("object"), new SchemaName(AvroTypeNames.Null));
-    public static readonly PrimitiveSchema Boolean = new PrimitiveSchema(SchemaType.Boolean, new CSharpName("bool"), new SchemaName(AvroTypeNames.Boolean));
-    public static readonly PrimitiveSchema Int = new PrimitiveSchema(SchemaType.Int, new CSharpName("int"), new SchemaName(AvroTypeNames.Int));
-    public static readonly PrimitiveSchema Long = new PrimitiveSchema(SchemaType.Long, new CSharpName("long"), new SchemaName(AvroTypeNames.Long));
-    public static readonly PrimitiveSchema Float = new PrimitiveSchema(SchemaType.Float, new CSharpName("float"), new SchemaName(AvroTypeNames.Float));
-    public static readonly PrimitiveSchema Double = new PrimitiveSchema(SchemaType.Double, new CSharpName("double"), new SchemaName(AvroTypeNames.Double));
-    public static readonly PrimitiveSchema Bytes = new PrimitiveSchema(SchemaType.Bytes, new CSharpName("byte[]"), new SchemaName(AvroTypeNames.Bytes));
-    public static readonly PrimitiveSchema String = new PrimitiveSchema(SchemaType.String, new CSharpName("string"), new SchemaName(AvroTypeNames.String));
+    public static readonly PrimitiveSchema Object = new(SchemaType.Null, new CSharpName("object"), new SchemaName(AvroTypeNames.Null));
+    public static readonly PrimitiveSchema Boolean = new(SchemaType.Boolean, new CSharpName("bool"), new SchemaName(AvroTypeNames.Boolean));
+    public static readonly PrimitiveSchema Int = new(SchemaType.Int, new CSharpName("int"), new SchemaName(AvroTypeNames.Int));
+    public static readonly PrimitiveSchema Long = new(SchemaType.Long, new CSharpName("long"), new SchemaName(AvroTypeNames.Long));
+    public static readonly PrimitiveSchema Float = new(SchemaType.Float, new CSharpName("float"), new SchemaName(AvroTypeNames.Float));
+    public static readonly PrimitiveSchema Double = new(SchemaType.Double, new CSharpName("double"), new SchemaName(AvroTypeNames.Double));
+    public static readonly PrimitiveSchema Bytes = new(SchemaType.Bytes, new CSharpName("byte[]"), new SchemaName(AvroTypeNames.Bytes));
+    public static readonly PrimitiveSchema String = new(SchemaType.String, new CSharpName("string"), new SchemaName(AvroTypeNames.String));
 }

--- a/src/AvroSourceGenerator.Core/Schemas/AvroSchemaReference.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/AvroSchemaReference.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 namespace AvroSourceGenerator.Schemas;
 
 public sealed record class AvroSchemaReference(SchemaName SchemaName)
-    : AvroSchema(SchemaType.Reference, CSharpName.FromSchemaName(SchemaName), SchemaName, ImmutableSortedDictionary<string, JsonElement>.Empty)
+    : AvroSchema(SchemaType.Reference, CSharpName.FromSchemaName(SchemaName), SchemaName, Documentation: null, ImmutableSortedDictionary<string, JsonElement>.Empty)
 {
     public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {

--- a/src/AvroSourceGenerator.Core/Schemas/LogicalSchema.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/LogicalSchema.cs
@@ -6,7 +6,7 @@ public sealed record class LogicalSchema(
     AvroSchema UnderlyingSchema,
     CSharpName CSharpName,
     SchemaName SchemaName)
-    : AvroSchema(SchemaType.Logical, CSharpName, SchemaName, UnderlyingSchema.Properties)
+    : AvroSchema(SchemaType.Logical, CSharpName, SchemaName, UnderlyingSchema.Documentation, UnderlyingSchema.Properties)
 {
     public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {

--- a/src/AvroSourceGenerator.Core/Schemas/MapSchema.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/MapSchema.cs
@@ -3,8 +3,8 @@ using System.Text.Json;
 
 namespace AvroSourceGenerator.Schemas;
 
-public sealed record class MapSchema(AvroSchema ValueSchema, ImmutableSortedDictionary<string, JsonElement> Properties)
-    : AvroSchema(SchemaType.Map, new CSharpName($"Dictionary<string, {ValueSchema}>", "System.Collections.Generic"), new SchemaName(AvroTypeNames.Map), Properties)
+public sealed record class MapSchema(AvroSchema ValueSchema, string? Documentation, ImmutableSortedDictionary<string, JsonElement> Properties)
+    : AvroSchema(SchemaType.Map, GetCSharpName(ValueSchema), new SchemaName(AvroTypeNames.Map), Documentation, Properties)
 {
     public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {
@@ -20,4 +20,6 @@ public sealed record class MapSchema(AvroSchema ValueSchema, ImmutableSortedDict
 
         writer.WriteEndObject();
     }
+
+    private static CSharpName GetCSharpName(AvroSchema valueSchema) => new($"Dictionary<string, {valueSchema}>", "System.Collections.Generic");
 }

--- a/src/AvroSourceGenerator.Core/Schemas/PrimitiveSchema.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/PrimitiveSchema.cs
@@ -3,11 +3,11 @@ using System.Text.Json;
 
 namespace AvroSourceGenerator.Schemas;
 
-public sealed record class PrimitiveSchema(SchemaType Type, CSharpName CSharpName, SchemaName SchemaName, ImmutableSortedDictionary<string, JsonElement> Properties)
-    : AvroSchema(Type, CSharpName, SchemaName, Properties)
+public sealed record class PrimitiveSchema(SchemaType Type, CSharpName CSharpName, SchemaName SchemaName, string? Documentation, ImmutableSortedDictionary<string, JsonElement> Properties)
+    : AvroSchema(Type, CSharpName, SchemaName, Documentation, Properties)
 {
     public PrimitiveSchema(SchemaType type, CSharpName csharpName, SchemaName schemaName)
-        : this(type, csharpName, schemaName, ImmutableSortedDictionary<string, JsonElement>.Empty) { }
+        : this(type, csharpName, schemaName, Documentation: null, ImmutableSortedDictionary<string, JsonElement>.Empty) { }
 
     public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {

--- a/src/AvroSourceGenerator.Core/Schemas/TopLevelSchema.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/TopLevelSchema.cs
@@ -9,4 +9,4 @@ public abstract record class TopLevelSchema(
     SchemaName SchemaName,
     string? Documentation,
     ImmutableSortedDictionary<string, JsonElement> Properties)
-    : AvroSchema(Type, CSharpName.FromSchemaName(SchemaName), SchemaName, Properties);
+    : AvroSchema(Type, CSharpName.FromSchemaName(SchemaName), SchemaName, Documentation, Properties);

--- a/src/AvroSourceGenerator.Core/Schemas/UnionSchema.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/UnionSchema.cs
@@ -8,7 +8,7 @@ public sealed record class UnionSchema(
     ImmutableArray<AvroSchema> Schemas,
     AvroSchema UnderlyingSchema,
     bool IsNullable)
-    : AvroSchema(SchemaType.Union, CSharpName, new SchemaName(string.Empty), ImmutableSortedDictionary<string, JsonElement>.Empty)
+    : AvroSchema(SchemaType.Union, CSharpName, new SchemaName(string.Empty), Documentation: null, ImmutableSortedDictionary<string, JsonElement>.Empty)
 {
     public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {


### PR DESCRIPTION
## Summary
- move reserved schema/protocol property filters into Extensions and expose GetSchemaProperties / GetProtocolProperties JSON extension methods
- simplify SchemaRegistry flow by removing explicit properties plumbing through parser methods
- preserve documentation when materializing primitive schemas from JSON object definitions
- rename recursion helper Track to EnterRecursionScope for clearer intent

## Validation
- dotnet build avro-source-generator.slnx -v minimal