### PR TITLE
Unify schema processing across files via SchemaRegistry

### DIFF
--- a/src/AvroSourceGenerator.Core/Configuration/DuplicateResolution.cs
+++ b/src/AvroSourceGenerator.Core/Configuration/DuplicateResolution.cs
@@ -1,6 +1,6 @@
 ﻿namespace AvroSourceGenerator.Configuration;
 
-internal enum DuplicateResolution
+public enum DuplicateResolution
 {
     Error,
     Ignore,

--- a/src/AvroSourceGenerator.Core/Exceptions/DuplicateSchemaException.cs
+++ b/src/AvroSourceGenerator.Core/Exceptions/DuplicateSchemaException.cs
@@ -1,0 +1,8 @@
+﻿using AvroSourceGenerator.Schemas;
+
+namespace AvroSourceGenerator.Exceptions;
+
+public sealed class DuplicateSchemaException(AvroSchema schema) : Exception($"Redeclaration of schema '{schema.SchemaName}'")
+{
+    public AvroSchema Schema { get; } = schema;
+}

--- a/src/AvroSourceGenerator.Core/Exceptions/InvalidSchemaException.cs
+++ b/src/AvroSourceGenerator.Core/Exceptions/InvalidSchemaException.cs
@@ -1,3 +1,3 @@
-﻿namespace AvroSourceGenerator.Schemas;
+﻿namespace AvroSourceGenerator.Exceptions;
 
 public sealed class InvalidSchemaException(string message) : Exception(message);

--- a/src/AvroSourceGenerator.Core/Extensions/JsonElementAvroExtensions.cs
+++ b/src/AvroSourceGenerator.Core/Extensions/JsonElementAvroExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Immutable;
 using System.Text.Json;
+using AvroSourceGenerator.Exceptions;
 using AvroSourceGenerator.Schemas;
 
 namespace AvroSourceGenerator.Extensions;

--- a/src/AvroSourceGenerator.Core/Extensions/JsonElementJsonExtensions.cs
+++ b/src/AvroSourceGenerator.Core/Extensions/JsonElementJsonExtensions.cs
@@ -1,5 +1,5 @@
 ﻿using System.Text.Json;
-using AvroSourceGenerator.Schemas;
+using AvroSourceGenerator.Exceptions;
 
 namespace AvroSourceGenerator.Extensions;
 

--- a/src/AvroSourceGenerator.Core/Extensions/StringAvroSchemaExtensions.cs
+++ b/src/AvroSourceGenerator.Core/Extensions/StringAvroSchemaExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using AvroSourceGenerator.Exceptions;
 using AvroSourceGenerator.Schemas;
 
 namespace AvroSourceGenerator.Extensions;

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Protocol.Types.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Protocol.Types.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Immutable;
 using System.Text.Json;
+using AvroSourceGenerator.Exceptions;
 using AvroSourceGenerator.Extensions;
 using AvroSourceGenerator.Schemas;
 

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Protocol.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Protocol.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using AvroSourceGenerator.Extensions;
 using AvroSourceGenerator.Protocols;
 using AvroSourceGenerator.Schemas;
@@ -10,10 +10,6 @@ public readonly partial struct SchemaRegistry
     private ProtocolSchema Protocol(JsonElement schema, string? containingNamespace)
     {
         var schemaName = schema.GetRequiredProtocolName(containingNamespace);
-
-        if (_schemas.ContainsKey(schemaName))
-            throw new InvalidSchemaException($"Redeclaration of schema '{schemaName}'");
-
         using (EnterRecursionScope(schemaName))
         {
             var documentation = schema.GetDocumentation();
@@ -22,7 +18,8 @@ public readonly partial struct SchemaRegistry
             var properties = schema.GetProtocolProperties();
 
             var protocolSchema = new ProtocolSchema(schema, schemaName, documentation, types, messages, properties);
-            _schemas[schemaName] = protocolSchema;
+
+            Register(protocolSchema);
 
             return protocolSchema;
         }

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Enum.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Enum.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using AvroSourceGenerator.Extensions;
 using AvroSourceGenerator.Schemas;
 
@@ -9,10 +9,6 @@ public readonly partial struct SchemaRegistry
     private EnumSchema Enum(JsonElement schema, string? containingNamespace)
     {
         var schemaName = schema.GetRequiredSchemaName(containingNamespace);
-
-        if (_schemas.ContainsKey(schemaName))
-            throw new InvalidSchemaException($"Redeclaration of schema '{schemaName}'");
-
         using (EnterRecursionScope(schemaName))
         {
             var documentation = schema.GetDocumentation();
@@ -22,7 +18,8 @@ public readonly partial struct SchemaRegistry
             var properties = schema.GetSchemaProperties();
 
             var enumSchema = new EnumSchema(schema, schemaName, documentation, aliases, symbols, @default, properties);
-            _schemas[schemaName] = enumSchema;
+
+            Register(enumSchema);
 
             return enumSchema;
         }

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Error.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Error.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using AvroSourceGenerator.Extensions;
 using AvroSourceGenerator.Schemas;
 
@@ -9,10 +9,6 @@ public readonly partial struct SchemaRegistry
     private ErrorSchema Error(JsonElement schema, string? containingNamespace)
     {
         var schemaName = schema.GetRequiredSchemaName(containingNamespace);
-
-        if (_schemas.ContainsKey(schemaName))
-            throw new InvalidSchemaException($"Redeclaration of schema '{schemaName}'");
-
         using (EnterRecursionScope(schemaName))
         {
             var documentation = schema.GetDocumentation();
@@ -21,7 +17,8 @@ public readonly partial struct SchemaRegistry
             var properties = schema.GetSchemaProperties();
 
             var errorSchema = new ErrorSchema(schema, schemaName, documentation, aliases, fields, properties);
-            _schemas[schemaName] = errorSchema;
+
+            Register(errorSchema);
 
             return errorSchema;
         }

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Fields.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Fields.cs
@@ -32,7 +32,9 @@ public readonly partial struct SchemaRegistry
                     if (union.SupportsVariant())
                     {
                         var variant = new VariantSchema(name, containingSchemaName, union.Schemas);
-                        _schemas.Add(variant.SchemaName, variant);
+                        // It is OK to ignore the result of TryRegister here. If a variant with the same name already exists
+                        // it means that it has the same set of types in the union, so we can just reuse it.
+                        _ = TryRegister(variant);
 
                         remarks = variant.Documentation;
                         union = union.WithVariant(variant);
@@ -44,7 +46,7 @@ public readonly partial struct SchemaRegistry
                 }
                 break;
 
-            case FixedSchema @fixed when targetProfile is not TargetProfile.Apache:
+            case FixedSchema @fixed when options.TargetProfile is not TargetProfile.Apache:
                 {
                     remarks = @fixed.Documentation;
                 }

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Fixed.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Fixed.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using AvroSourceGenerator.Configuration;
 using AvroSourceGenerator.Extensions;
 using AvroSourceGenerator.Schemas;
@@ -10,10 +10,6 @@ public readonly partial struct SchemaRegistry
     private FixedSchema Fixed(JsonElement schema, string? containingNamespace)
     {
         var schemaName = schema.GetRequiredSchemaName(containingNamespace);
-
-        if (_schemas.ContainsKey(schemaName))
-            throw new InvalidSchemaException($"Redeclaration of schema '{schemaName}'");
-
         using (EnterRecursionScope(schemaName))
         {
             var documentation = schema.GetDocumentation();
@@ -21,14 +17,14 @@ public readonly partial struct SchemaRegistry
             var size = schema.GetFixedSize();
             var properties = schema.GetSchemaProperties();
 
-            var fixedSchema = targetProfile switch
+            var fixedSchema = options.TargetProfile switch
             {
                 // Only Apache.Avro needs a custom type for fixed, others use byte[].
                 TargetProfile.Apache => new FixedSchema(schema, schemaName, documentation, aliases, size, properties),
                 _ => FixedSchema.CreateAsByteArray(schema, schemaName, documentation, aliases, size, properties),
             };
 
-            _schemas[schemaName] = fixedSchema;
+            Register(fixedSchema);
 
             return fixedSchema;
         }

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Logical.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Logical.cs
@@ -11,7 +11,7 @@ public readonly partial struct SchemaRegistry
     {
         var logicalType = schema.GetRequiredString(AvroJsonKeys.LogicalType);
 
-        return targetProfile switch
+        return options.TargetProfile switch
         {
             TargetProfile.Apache =>
                 LogicalSchema.ForApache(logicalType, underlyingSchema),
@@ -25,7 +25,7 @@ public readonly partial struct SchemaRegistry
             TargetProfile.Modern =>
                 LogicalSchema.ForModern(logicalType, underlyingSchema),
 
-            _ => throw new InvalidOperationException($"Unsupported {nameof(TargetProfile)} '{targetProfile}'"),
+            _ => throw new InvalidOperationException($"Unsupported {nameof(TargetProfile)} '{options.TargetProfile}'"),
         };
     }
 }

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Record.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Record.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using AvroSourceGenerator.Extensions;
 using AvroSourceGenerator.Schemas;
 
@@ -9,10 +9,6 @@ public readonly partial struct SchemaRegistry
     private RecordSchema Record(JsonElement schema, string? containingNamespace)
     {
         var schemaName = schema.GetRequiredSchemaName(containingNamespace);
-
-        if (_schemas.ContainsKey(schemaName))
-            throw new InvalidSchemaException($"Redeclaration of schema '{schemaName}'");
-
         using (EnterRecursionScope(schemaName))
         {
             var documentation = schema.GetDocumentation();
@@ -22,7 +18,7 @@ public readonly partial struct SchemaRegistry
 
             var recordSchema = new RecordSchema(schema, schemaName, documentation, aliases, fields, properties);
 
-            _schemas[schemaName] = recordSchema;
+            Register(recordSchema);
 
             return recordSchema;
         }

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Union.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.Schema.Union.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Text.Json;
 using AvroSourceGenerator.Schemas;
 
@@ -17,7 +17,7 @@ public readonly partial struct SchemaRegistry
         var underlyingSchema = GetUnderlyingSchema(schemas);
         while (underlyingSchema is UnionSchema { Schemas: var unionSchemas })
             underlyingSchema = GetUnderlyingSchema(unionSchemas);
-        var hasQuestionMark = isNullable && (useNullableReferenceTypes || MapsToValueType(underlyingSchema.Type));
+        var hasQuestionMark = isNullable && (options.UseNullableReferenceTypes || MapsToValueType(underlyingSchema.Type));
         var csharpName = new CSharpName(
             underlyingSchema.CSharpName.Name + (hasQuestionMark ? "?" : ""),
             underlyingSchema.CSharpName.Namespace);

--- a/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.cs
+++ b/src/AvroSourceGenerator.Core/Registry/SchemaRegistry.cs
@@ -1,20 +1,25 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using AvroSourceGenerator.Configuration;
+using AvroSourceGenerator.Exceptions;
 using AvroSourceGenerator.Extensions;
 using AvroSourceGenerator.Schemas;
 
 namespace AvroSourceGenerator.Registry;
 
+public readonly record struct SchemaRegistryOptions(TargetProfile TargetProfile, DuplicateResolution DuplicateResolution, bool UseNullableReferenceTypes)
+{
+    public static readonly SchemaRegistryOptions Default = new(TargetProfile.Modern, DuplicateResolution.Error, true);
+}
+
 [StructLayout(LayoutKind.Auto)]
 [SuppressMessage("ReSharper", "UsageOfDefaultStructEquality")]
-public readonly partial struct SchemaRegistry(TargetProfile targetProfile, bool useNullableReferenceTypes) : IReadOnlyCollection<TopLevelSchema>
+public readonly partial struct SchemaRegistry(SchemaRegistryOptions options) : IReadOnlyCollection<TopLevelSchema>
 {
     private readonly Dictionary<SchemaName, TopLevelSchema> _schemas = [];
     private readonly List<SchemaName> _recursionStack = [];
-
 
     public int Count => _schemas.Count;
 
@@ -23,22 +28,45 @@ public readonly partial struct SchemaRegistry(TargetProfile targetProfile, bool 
 
     public IReadOnlyDictionary<SchemaName, TopLevelSchema> Schemas => _schemas;
 
-    public static SchemaRegistry Register(JsonElement schema, TargetProfile targetProfile, bool useNullableReferenceTypes)
+    public void Register(JsonElement schema)
     {
-        var registry = new SchemaRegistry(targetProfile, useNullableReferenceTypes);
+        _ = Schema(schema, containingNamespace: null);
 
-        _ = registry.Schema(schema, containingNamespace: null);
-
-        if (registry.Count == 0)
+        // TODO: We need to check that the returned schema contains at least a named schema.
+        if (Count == 0)
         {
             throw new InvalidSchemaException($"At least a named schema must be present in schema: {schema.GetRawText()}");
         }
+    }
 
-        return registry;
+    private void Register(TopLevelSchema schema)
+    {
+        if (TryRegister(schema))
+        {
+            return;
+        }
+
+        if (options.DuplicateResolution == DuplicateResolution.Ignore)
+        {
+            return;
+        }
+
+        // TODO: Needs to be its own exception type so we can report a proper diagnostic.
+        throw new DuplicateSchemaException(schema);
+
+        // TODO: We should probably add 'Replace' resolution as well.
+    }
+
+    private bool TryRegister(TopLevelSchema schema)
+    {
+        if (_schemas.ContainsKey(schema.SchemaName)) return false;
+        _schemas[schema.SchemaName] = schema;
+        return true;
     }
 
     private AvroSchema? FindByName(string name, string? containingNamespace)
     {
+        // TODO: Isn't this an issue for types that have names that collide with primitive types? Do we need to support that?
         switch (name)
         {
             case AvroTypeNames.Null: return AvroSchema.Object;
@@ -123,6 +151,7 @@ public readonly partial struct SchemaRegistry(TargetProfile targetProfile, bool 
         return wellKnown;
     }
 
+    // TODO: This should probably be in AvroSchema hierarchy instead of being here.
     private string? GetValue(AvroSchema type, JsonElement? json)
     {
         if (json is null or { ValueKind: JsonValueKind.Null or JsonValueKind.Undefined })
@@ -140,8 +169,7 @@ public readonly partial struct SchemaRegistry(TargetProfile targetProfile, bool 
             "double" => value.GetRawText(),
             "byte[]" => $"[{string.Join(", ", value.GetBytesFromBase64().Select(bytes => $"0x{bytes:X2}"))}]",
             "string" => value.GetRawText(),
-            _ when _schemas.TryGetValue(type.SchemaName, out var namedSchema) && namedSchema.Type is SchemaType.Enum =>
-                $"{type}.{value.GetString()}",
+            _ when type.Type is SchemaType.Enum => $"{type}.{value.GetString()}",
 
             // TODO: Do we need to handle complex types? Should they be supported?
             _ => null,

--- a/src/AvroSourceGenerator/AvroSourceGenerator.cs
+++ b/src/AvroSourceGenerator/AvroSourceGenerator.cs
@@ -9,9 +9,10 @@ public sealed class AvroSourceGenerator : IIncrementalGenerator
 {
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        var avroFileProvider = context.AdditionalTextsProvider
+        var avroFilesProvider = context.AdditionalTextsProvider
             .Where(Parser.IsAvroFile)
             .Select(Parser.GetAvroFile)
+            .Collect()
             .WithTrackingName(TrackingNames.AvroFiles);
 
         var generatorSettingsProvider = context.AnalyzerConfigOptionsProvider
@@ -26,12 +27,13 @@ public sealed class AvroSourceGenerator : IIncrementalGenerator
             .Select(Parser.GetRenderSettings)
             .WithTrackingName(TrackingNames.RenderSettings);
 
-        var renderResultProvider = avroFileProvider.Combine(renderSettingsProvider)
+        var renderResultProvider = avroFilesProvider
+            .Combine(renderSettingsProvider)
             .Select(Renderer.Render)
             .WithTrackingName(TrackingNames.RenderResult);
 
-        var renderResultsProvider = renderResultProvider.Collect()
-            .Combine(renderSettingsProvider)
+        // TODO: We probably don't need this tracking name/step anymore.
+        var renderResultsProvider = renderResultProvider
             .WithTrackingName(TrackingNames.Emitter);
 
         context.RegisterImplementationSourceOutput(renderResultsProvider, Emitter.Emit);

--- a/src/AvroSourceGenerator/Emit/Emitter.cs
+++ b/src/AvroSourceGenerator/Emit/Emitter.cs
@@ -1,8 +1,4 @@
-﻿using System.Collections.Immutable;
-using System.Text;
-using AvroSourceGenerator.Configuration;
-using AvroSourceGenerator.Diagnostics;
-using AvroSourceGenerator.Parsing;
+﻿using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 
@@ -10,30 +6,16 @@ namespace AvroSourceGenerator.Emit;
 
 internal static class Emitter
 {
-    public static void Emit(SourceProductionContext context, (ImmutableArray<RenderResult> results, RenderSettings settings) source)
+    public static void Emit(SourceProductionContext context, RenderResult result)
     {
-        var (results, settings) = source;
-
-        var seenNames = new HashSet<string>();
-
-        foreach (var result in results)
+        foreach (var diagnostic in result.Diagnostics)
         {
-            foreach (var diagnostic in result.Diagnostics)
-            {
-                context.ReportDiagnostic(diagnostic);
-            }
+            context.ReportDiagnostic(diagnostic);
+        }
 
-            foreach (var schema in result.Schemas)
-            {
-                if (seenNames.Add(schema.HintName))
-                {
-                    context.AddSource(schema.HintName, SourceText.From(schema.SourceText, Encoding.UTF8));
-                }
-                else if (settings.DuplicateResolution is not DuplicateResolution.Ignore)
-                {
-                    context.ReportDiagnostic(DuplicateSchemaOutputDiagnostic.Create(LocationInfo.None, schema.HintName));
-                }
-            }
+        foreach (var schema in result.Schemas)
+        {
+            context.AddSource(schema.HintName, SourceText.From(schema.SourceText, Encoding.UTF8));
         }
     }
 }

--- a/src/AvroSourceGenerator/Emit/Renderer.cs
+++ b/src/AvroSourceGenerator/Emit/Renderer.cs
@@ -1,51 +1,60 @@
-﻿using System.Text.Json;
+﻿using System.Collections.Immutable;
+using System.Text.Json;
 using AvroSourceGenerator.Configuration;
 using AvroSourceGenerator.Diagnostics;
+using AvroSourceGenerator.Exceptions;
 using AvroSourceGenerator.Parsing;
 using AvroSourceGenerator.Registry;
-using AvroSourceGenerator.Schemas;
 
 namespace AvroSourceGenerator.Emit;
 
 internal static class Renderer
 {
-    public static RenderResult Render((AvroFile avroFile, RenderSettings renderSettings) source, CancellationToken cancellationToken)
+    public static RenderResult Render((ImmutableArray<AvroFile> avroFiles, RenderSettings renderSettings) source, CancellationToken cancellationToken)
     {
-        var (avroFile, settings) = source;
+        var (avroFiles, settings) = source;
 
-        var diagnostics = avroFile.Diagnostics.AddRange(settings.Diagnostics);
+        var diagnostics = settings.Diagnostics.AddRange(avroFiles.SelectMany(avroFile => avroFile.Diagnostics));
 
-        if (!avroFile.IsValid || !settings.IsValid)
+        // TODO: We can probably skip invalid files and just render the valid ones, but for now we'll just return an empty result if there are any errors.
+        if (!settings.IsValid || avroFiles.Any(avroFile => !avroFile.IsValid))
         {
             return new RenderResult([], diagnostics);
         }
 
-        try
-        {
-            var schemaRegistry = SchemaRegistry.Register(
-                schema: avroFile.Json,
-                targetProfile: settings.TargetProfile,
-                useNullableReferenceTypes: settings.LanguageFeatures.HasFlag(LanguageFeatures.NullableReferenceTypes));
+        var schemaRegistry = new SchemaRegistry(
+            new SchemaRegistryOptions(
+                TargetProfile: settings.TargetProfile,
+                UseNullableReferenceTypes: settings.LanguageFeatures.HasFlag(LanguageFeatures.NullableReferenceTypes),
+                DuplicateResolution: settings.DuplicateResolution));
 
-            // We should get no render errors, so we don't have to handle anything else.
-            var schemas = AvroTemplate.Render(schemaRegistry, settings);
+        foreach (var avroFile in avroFiles)
+        {
+            try
+            {
+                schemaRegistry.Register(schema: avroFile.Json);
+            }
+            catch (JsonException ex)
+            {
+                diagnostics = diagnostics.Add(InvalidJsonDiagnostic.Create(LocationInfo.FromException(avroFile.Path, avroFile.Text, ex), ex.Message));
+            }
+            catch (DuplicateSchemaException ex)
+            {
+                diagnostics = diagnostics.Add(DuplicateSchemaOutputDiagnostic.Create(LocationInfo.None, $"{ex.Schema.SchemaName}.Avro.g.cs"));
+            }
+            catch (InvalidSchemaException ex)
+            {
+                // TODO: We can probably get a better location for the error.
+                diagnostics = diagnostics.Add(InvalidSchemaDiagnostic.Create(LocationInfo.FromSourceFile(avroFile.Path, avroFile.Text), ex.Message));
+            }
+            catch (Exception ex)
+            {
+                diagnostics = diagnostics.Add(UnknownErrorDiagnostic.Create(LocationInfo.FromSourceFile(avroFile.Path, avroFile.Text), ex.Message));
+            }
+        }
 
-            return new RenderResult(schemas, diagnostics);
-        }
-        catch (JsonException ex)
-        {
-            diagnostics = diagnostics.Add(InvalidJsonDiagnostic.Create(LocationInfo.FromException(avroFile.Path, avroFile.Text, ex), ex.Message));
-        }
-        catch (InvalidSchemaException ex)
-        {
-            // TODO: We can probably get a better location for the error.
-            diagnostics = diagnostics.Add(InvalidSchemaDiagnostic.Create(LocationInfo.FromSourceFile(avroFile.Path, avroFile.Text), ex.Message));
-        }
-        catch (Exception ex)
-        {
-            diagnostics = diagnostics.Add(UnknownErrorDiagnostic.Create(LocationInfo.FromSourceFile(avroFile.Path, avroFile.Text), ex.Message));
-        }
+        var renderedSchemas = AvroTemplate.Render(schemaRegistry, settings);
 
-        return new RenderResult([], diagnostics);
+        return new RenderResult(renderedSchemas, diagnostics);
     }
 }

--- a/src/AvroSourceGenerator/Parsing/Parser.cs
+++ b/src/AvroSourceGenerator/Parsing/Parser.cs
@@ -2,8 +2,8 @@
 using System.Text.Json;
 using AvroSourceGenerator.Configuration;
 using AvroSourceGenerator.Diagnostics;
+using AvroSourceGenerator.Exceptions;
 using AvroSourceGenerator.Extensions;
-using AvroSourceGenerator.Schemas;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/tests/AvroSourceGenerator.Tests/AvroSourceGenerator.Tests.csproj
+++ b/tests/AvroSourceGenerator.Tests/AvroSourceGenerator.Tests.csproj
@@ -28,13 +28,4 @@
     <ProjectReference Include="..\..\src\AvroSourceGenerator.Core\AvroSourceGenerator.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Update="FieldCollectionTests.Verify_class=record_field=array-string-.verified.txt">
-      <DependentUpon>FieldCollectionTests.cs</DependentUpon>
-    </None>
-    <None Update="FieldCollectionTests.Verify_class=record_field=array-string-.received.txt">
-      <DependentUpon>FieldCollectionTests.cs</DependentUpon>
-    </None>
-  </ItemGroup>
-
 </Project>

--- a/tests/AvroSourceGenerator.Tests/JsonElementAvroExtensionsTests.cs
+++ b/tests/AvroSourceGenerator.Tests/JsonElementAvroExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json;
+using AvroSourceGenerator.Exceptions;
 using AvroSourceGenerator.Extensions;
 using AvroSourceGenerator.Schemas;
 

--- a/tests/AvroSourceGenerator.Tests/SchemaRegistryReservedPropertiesTests.cs
+++ b/tests/AvroSourceGenerator.Tests/SchemaRegistryReservedPropertiesTests.cs
@@ -1,7 +1,6 @@
-using System.Text.Json;
-using AvroSourceGenerator.Configuration;
-using AvroSourceGenerator.Registry;
+﻿using System.Text.Json;
 using AvroSourceGenerator.Protocols;
+using AvroSourceGenerator.Registry;
 using AvroSourceGenerator.Schemas;
 
 namespace AvroSourceGenerator.Tests;
@@ -34,7 +33,8 @@ public sealed class SchemaRegistryReservedPropertiesTests
             }
             """);
 
-        var registry = SchemaRegistry.Register(schema, TargetProfile.Modern, useNullableReferenceTypes: true);
+        var registry = new SchemaRegistry(SchemaRegistryOptions.Default);
+        registry.Register(schema);
         var record = Assert.IsType<RecordSchema>(Assert.Single(registry.Schemas.Values));
         var field = Assert.Single(record.Fields);
 
@@ -61,7 +61,8 @@ public sealed class SchemaRegistryReservedPropertiesTests
             }
             """);
 
-        var registry = SchemaRegistry.Register(schema, TargetProfile.Modern, useNullableReferenceTypes: true);
+        var registry = new SchemaRegistry(SchemaRegistryOptions.Default);
+        registry.Register(schema);
         var protocol = Assert.IsType<ProtocolSchema>(Assert.Single(registry.Schemas.Values));
 
         Assert.Equal(["x-protocol"], protocol.Properties.Keys);


### PR DESCRIPTION
## Summary
- process all .avsc inputs together through a single SchemaRegistry pass
- move duplicate detection/handling to registry-level behavior across the full input set
- render once after registration to avoid repeated output emission
- add/adjust supporting exception, parser, emitter, and tests to reflect the new flow

## Why
The core goal of this change is to handle all files together in the same SchemaRegistry, detecting and handling duplicates there. This removes per-file processing artifacts and is an important step toward robust support for external references spanning multiple schema files.

## Notes
- includes all current branch changes (including staged work)
- branch: schema-registry-all-files
