### PR TITLE
Add Chr.Avro Kafka sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,20 @@ partial record User : global::Avro.Specific.ISpecificRecord
 
 ---
 
+## Samples
+
+- [samples/AvroSourceGenerator.ApacheAvro/AvroSourceGenerator.ApacheAvro.csproj](samples/AvroSourceGenerator.ApacheAvro/AvroSourceGenerator.ApacheAvro.csproj) shows a minimal `Apache.Avro` model generation flow.
+- [samples/AvroSourceGenerator.ConfluentKafka/AvroSourceGenerator.ConfluentKafka.csproj](samples/AvroSourceGenerator.ConfluentKafka/AvroSourceGenerator.ConfluentKafka.csproj) shows Kafka and Schema Registry integration using Confluent's Avro serializer.
+- [samples/AvroSourceGenerator.ChrAvroKafka/AvroSourceGenerator.ChrAvroKafka.csproj](samples/AvroSourceGenerator.ChrAvroKafka/AvroSourceGenerator.ChrAvroKafka.csproj) shows the same Kafka and Schema Registry container workflow using `Chr.Avro.Confluent`.
+
+You can run any sample with:
+
+```bash
+dotnet run --project samples/AvroSourceGenerator.ChrAvroKafka/AvroSourceGenerator.ChrAvroKafka.csproj
+```
+
+---
+
 ## Extending Generated Types
 
 All generated types are declared as `partial`, allowing you to add members or behavior:

--- a/avro-source-generator.slnx
+++ b/avro-source-generator.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Folder Name="/samples/">
     <Project Path="samples/AvroSourceGenerator.ApacheAvro/AvroSourceGenerator.ApacheAvro.csproj" />
+    <Project Path="samples/AvroSourceGenerator.ChrAvroKafka/AvroSourceGenerator.ChrAvroKafka.csproj" />
     <Project Path="samples/AvroSourceGenerator.ConfluentKafka/AvroSourceGenerator.ConfluentKafka.csproj" />
   </Folder>
   <Folder Name="/Solution Items/">

--- a/samples/AvroSourceGenerator.ChrAvroKafka/AvroSourceGenerator.ChrAvroKafka.csproj
+++ b/samples/AvroSourceGenerator.ChrAvroKafka/AvroSourceGenerator.ChrAvroKafka.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AvroSourceGeneratorAvroLibrary>Chr</AvroSourceGeneratorAvroLibrary>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Chr.Avro.Confluent" />
+    <PackageReference Include="Testcontainers" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <CompilerVisibleProperty Include="AvroSourceGeneratorAvroLibrary" />
+    <CompilerVisibleProperty Include="AvroSourceGeneratorLanguageFeatures" />
+    <CompilerVisibleProperty Include="AvroSourceGeneratorAccessModifier" />
+    <CompilerVisibleProperty Include="AvroSourceGeneratorRecordDeclaration" />
+    <CompilerVisibleProperty Include="AvroSourceGeneratorDuplicateResolution" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="*.avsc" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AvroSourceGenerator\AvroSourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/samples/AvroSourceGenerator.ChrAvroKafka/DockerFixture.cs
+++ b/samples/AvroSourceGenerator.ChrAvroKafka/DockerFixture.cs
@@ -1,0 +1,194 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using Chr.Avro.Confluent;
+using Confluent.Kafka;
+using Confluent.SchemaRegistry;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Networks;
+
+namespace AvroSourceGenerator.ChrAvroKafka;
+
+public sealed class DockerFixture : IAsyncDisposable
+{
+    public INetwork Network { get; }
+    public IContainer Kafka { get; }
+    public IContainer SchemaRegistry { get; }
+
+    public DockerFixture()
+    {
+        Network = new NetworkBuilder()
+            .WithName($"network-{Guid.NewGuid()}")
+            .Build();
+
+        var kafkaName = $"kraft-kafka-{Guid.NewGuid()}";
+        var kafkaPort = GetFreeTcpPort();
+
+        Kafka = new ContainerBuilder("confluentinc/cp-kafka:7.6.1")
+            .WithName(kafkaName)
+            .WithPortBinding(kafkaPort, 9092)
+            .WithNetworkAliases(kafkaName)
+            .WithNetwork(Network)
+            .WithEnvironment(
+                new Dictionary<string, string>
+                {
+                    ["KAFKA_NODE_ID"] = "1",
+                    ["KAFKA_LISTENER_SECURITY_PROTOCOL_MAP"] =
+                        "PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,CONTROLLER:PLAINTEXT",
+                    ["KAFKA_LISTENERS"] =
+                        "PLAINTEXT://0.0.0.0:29092,PLAINTEXT_HOST://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093",
+                    ["KAFKA_ADVERTISED_LISTENERS"] =
+                        $"PLAINTEXT://{kafkaName}:29092,PLAINTEXT_HOST://localhost:{kafkaPort}",
+                    ["KAFKA_PROCESS_ROLES"] = "broker,controller",
+                    ["KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR"] = "1",
+                    ["KAFKA_CONTROLLER_QUORUM_VOTERS"] = $"1@{kafkaName}:9093",
+                    ["KAFKA_INTER_BROKER_LISTENER_NAME"] = "PLAINTEXT",
+                    ["KAFKA_CONTROLLER_LISTENER_NAMES"] = "CONTROLLER",
+                    ["CLUSTER_ID"] = GenerateClusterId(),
+                })
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(29092))
+            .Build();
+
+        var schemaRegistryName = $"schema-registry-{Guid.NewGuid()}";
+
+        SchemaRegistry = new ContainerBuilder("confluentinc/cp-schema-registry:7.6.0")
+            .WithName(schemaRegistryName)
+            .WithPortBinding(8081, assignRandomHostPort: true)
+            .WithNetworkAliases(schemaRegistryName)
+            .WithNetwork(Network)
+            .WithEnvironment(
+                new Dictionary<string, string>
+                {
+                    ["SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS"] = $"{kafkaName}:29092",
+                    ["SCHEMA_REGISTRY_HOST_NAME"] = schemaRegistryName,
+                    ["SCHEMA_REGISTRY_HOST_LISTENERS"] = "http://0.0.0.0:8081",
+                    ["SCHEMA_REGISTRY_DEBUG"] = "true",
+                })
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(8081))
+            .Build();
+
+        static string GenerateClusterId()
+        {
+            Span<char> clusterId = stackalloc char[22];
+            RandomNumberGenerator.GetItems("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789", clusterId);
+            return clusterId.ToString();
+        }
+    }
+
+    public async ValueTask StartAsync(CancellationToken cancellationToken = default)
+    {
+        await Network.CreateAsync(cancellationToken);
+        await Kafka.StartAsync(cancellationToken);
+        await SchemaRegistry.StartAsync(cancellationToken);
+    }
+
+    public async ValueTask DisposeAsync() => await Task.WhenAll(
+        SchemaRegistry.StopAsync(),
+        Kafka.StopAsync(),
+        Network.DeleteAsync());
+
+    public ISchemaRegistryClient CreateSchemaRegistryClient(Action<SchemaRegistryConfig>? configure = null)
+    {
+        var config = new SchemaRegistryConfig
+        {
+            Url = $"http://{SchemaRegistry.Hostname}:{SchemaRegistry.GetMappedPublicPort(8081)}",
+        };
+
+        configure?.Invoke(config);
+
+        return new CachedSchemaRegistryClient(config);
+    }
+
+    public async Task<IProducer<string, T>> CreateProducerAsync<T>(
+        ISchemaRegistryClient schemaRegistryClient,
+        string valueSubject,
+        Action<ProducerConfig>? configure = null)
+    {
+        var config = new ProducerConfig
+        {
+            BootstrapServers = $"{Kafka.Hostname}:{Kafka.GetMappedPublicPort(9092)}",
+            MessageTimeoutMs = 10000,
+        };
+
+        configure?.Invoke(config);
+
+        var builder = new ProducerBuilder<string, T>(config)
+            .SetKeySerializer(Serializers.Utf8);
+
+        builder = await builder.SetAvroValueSerializer(
+            schemaRegistryClient,
+            valueSubject,
+            AutomaticRegistrationBehavior.Always,
+            TombstoneBehavior.None);
+
+        return builder.Build();
+    }
+
+    public IConsumer<string, T> CreateConsumer<T>(
+        ISchemaRegistryClient schemaRegistryClient,
+        Action<ConsumerConfig>? configure = null)
+    {
+        var config = new ConsumerConfig
+        {
+            BootstrapServers = $"{Kafka.Hostname}:{Kafka.GetMappedPublicPort(9092)}",
+            GroupId = Guid.NewGuid().ToString("N"),
+            AutoOffsetReset = AutoOffsetReset.Earliest,
+        };
+
+        configure?.Invoke(config);
+
+        return new ConsumerBuilder<string, T>(config)
+            .SetKeyDeserializer(Deserializers.Utf8)
+            .SetAvroValueDeserializer(schemaRegistryClient, TombstoneBehavior.None)
+            .Build();
+    }
+
+    public async Task CreateTopicAsync(
+        string topicName,
+        int partitionCount = 1,
+        int replicationFactor = 1,
+        CancellationToken cancellationToken = default)
+    {
+        var createTopicResult = await Kafka.ExecAsync(
+            [
+                "kafka-topics", "--create",
+                "--topic", topicName,
+                "--partitions", partitionCount.ToString(),
+                "--replication-factor", replicationFactor.ToString(),
+                "--bootstrap-server", "0.0.0.0:29092"
+            ],
+            cancellationToken);
+
+        if (!string.IsNullOrEmpty(createTopicResult.Stderr))
+        {
+            throw new InvalidOperationException(
+                $"Failed to create topic '{topicName}': {createTopicResult.Stderr}");
+        }
+    }
+
+    public async Task DeleteTopicAsync(string topicName, CancellationToken cancellationToken = default)
+    {
+        var deleteTopicResult = await Kafka.ExecAsync(
+            [
+                "kafka-topics", "--delete",
+                "--topic", topicName,
+                "--bootstrap-server", "0.0.0.0:29092"
+            ],
+            cancellationToken);
+
+        if (!string.IsNullOrEmpty(deleteTopicResult.Stderr))
+        {
+            throw new InvalidOperationException(
+                $"Failed to delete topic '{topicName}': {deleteTopicResult.Stderr}");
+        }
+    }
+
+    private static int GetFreeTcpPort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+
+        return ((IPEndPoint)listener.LocalEndpoint).Port;
+    }
+}

--- a/samples/AvroSourceGenerator.ChrAvroKafka/Program.cs
+++ b/samples/AvroSourceGenerator.ChrAvroKafka/Program.cs
@@ -1,0 +1,152 @@
+using AvroSourceGenerator.ChrAvroKafka;
+using Confluent.Kafka;
+
+const string topicName = "transactions";
+var valueSubject = $"{topicName}-value";
+
+Console.WriteLine("Starting Kafka and Schema Registry containers...");
+await using var fixture = new DockerFixture();
+await fixture.StartAsync();
+Console.WriteLine("Containers are ready.");
+
+Console.WriteLine($"Creating topic '{topicName}'...");
+await fixture.CreateTopicAsync(topicName);
+Console.WriteLine($"Topic '{topicName}' created.");
+
+using var registry = fixture.CreateSchemaRegistryClient();
+
+Console.WriteLine("Creating a sample transaction...");
+var producedTransaction = CreateTransaction();
+Console.WriteLine($"Transaction {producedTransaction.Id} created.");
+
+Console.WriteLine("Creating producer...");
+using var producer = await fixture.CreateProducerAsync<TransactionEvent>(registry, valueSubject);
+
+Console.WriteLine("Producing message...");
+var deliveryResult = await producer.ProduceAsync(
+    topicName,
+    new Message<string, TransactionEvent>
+    {
+        Key = producedTransaction.Id.ToString(),
+        Value = producedTransaction,
+    });
+
+if (deliveryResult.Status != PersistenceStatus.Persisted)
+{
+    throw new InvalidOperationException($"Failed to produce message: {deliveryResult.Status}");
+}
+
+var registeredSchema = await registry.GetLatestSchemaAsync(valueSubject);
+Console.WriteLine(
+    $"Registered subject '{valueSubject}' at version {registeredSchema.Version} with schema id {registeredSchema.Id}.");
+
+Console.WriteLine("Creating consumer...");
+using var consumer = fixture.CreateConsumer<TransactionEvent>(registry);
+
+Console.WriteLine("Subscribing and consuming...");
+consumer.Subscribe(topicName);
+
+var consumedTransaction = consumer.Consume(TimeSpan.FromSeconds(10))?.Message?.Value
+    ?? throw new InvalidOperationException("Failed to consume the produced transaction.");
+
+Console.WriteLine($"Consumed transaction {consumedTransaction.Id}.");
+
+AssertEquivalent(producedTransaction, consumedTransaction);
+Console.WriteLine("Produced and consumed transactions match.");
+
+Console.WriteLine($"Deleting topic '{topicName}'...");
+await fixture.DeleteTopicAsync(topicName);
+Console.WriteLine("Sample completed successfully.");
+
+static TransactionEvent CreateTransaction()
+{
+    var timestamp = DateTimeOffset.UtcNow;
+    timestamp = timestamp.AddTicks(-(timestamp.Ticks % TimeSpan.TicksPerMillisecond));
+
+    var signature = new byte[64];
+    Random.Shared.NextBytes(signature);
+
+    return new TransactionEvent
+    {
+        Id = Guid.NewGuid(),
+        Amount = 123.45m,
+        Currency = "EUR",
+        Timestamp = timestamp,
+        Status = TransactionStatus.COMPLETED,
+        RecipientId = "merchant-42",
+        Metadata = new Dictionary<string, string>
+        {
+            ["channel"] = "web",
+            ["region"] = "eu-west",
+        },
+        Signature = signature,
+        LegacyId = "legacy-0001",
+    };
+}
+
+static void AssertEquivalent(TransactionEvent expected, TransactionEvent actual)
+{
+    if (expected.Id != actual.Id)
+    {
+        throw new InvalidOperationException($"Id mismatch: expected {expected.Id}, got {actual.Id}.");
+    }
+
+    if (expected.Amount != actual.Amount)
+    {
+        throw new InvalidOperationException($"Amount mismatch: expected {expected.Amount}, got {actual.Amount}.");
+    }
+
+    if (!string.Equals(expected.Currency, actual.Currency, StringComparison.Ordinal))
+    {
+        throw new InvalidOperationException(
+            $"Currency mismatch: expected '{expected.Currency}', got '{actual.Currency}'.");
+    }
+
+    if (expected.Timestamp != actual.Timestamp)
+    {
+        throw new InvalidOperationException(
+            $"Timestamp mismatch: expected {expected.Timestamp:o}, got {actual.Timestamp:o}.");
+    }
+
+    if (expected.Status != actual.Status)
+    {
+        throw new InvalidOperationException($"Status mismatch: expected {expected.Status}, got {actual.Status}.");
+    }
+
+    if (!string.Equals(expected.RecipientId, actual.RecipientId, StringComparison.Ordinal))
+    {
+        throw new InvalidOperationException(
+            $"RecipientId mismatch: expected '{expected.RecipientId}', got '{actual.RecipientId}'.");
+    }
+
+    if (!string.Equals(expected.LegacyId, actual.LegacyId, StringComparison.Ordinal))
+    {
+        throw new InvalidOperationException(
+            $"LegacyId mismatch: expected '{expected.LegacyId}', got '{actual.LegacyId}'.");
+    }
+
+    if (!expected.Signature.SequenceEqual(actual.Signature))
+    {
+        throw new InvalidOperationException("Signature mismatch.");
+    }
+
+    if (expected.Metadata.Count != actual.Metadata.Count)
+    {
+        throw new InvalidOperationException(
+            $"Metadata count mismatch: expected {expected.Metadata.Count}, got {actual.Metadata.Count}.");
+    }
+
+    foreach (var (key, value) in expected.Metadata)
+    {
+        if (!actual.Metadata.TryGetValue(key, out var actualValue))
+        {
+            throw new InvalidOperationException($"Metadata key '{key}' was not found in the consumed transaction.");
+        }
+
+        if (!string.Equals(value, actualValue, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Metadata mismatch for '{key}': expected '{value}', got '{actualValue}'.");
+        }
+    }
+}

--- a/samples/AvroSourceGenerator.ChrAvroKafka/TransactionEvent.avsc
+++ b/samples/AvroSourceGenerator.ChrAvroKafka/TransactionEvent.avsc
@@ -1,0 +1,71 @@
+{
+  "type": "record",
+  "name": "TransactionEvent",
+  "namespace": "AvroSourceGenerator.ChrAvroKafka",
+  "doc": "Represents a financial transaction that is published to Kafka.",
+  "fields": [
+    {
+      "name": "Id",
+      "type": {
+        "type": "string",
+        "logicalType": "uuid"
+      }
+    },
+    {
+      "name": "Amount",
+      "type": {
+        "type": "bytes",
+        "logicalType": "decimal",
+        "precision": 10,
+        "scale": 2
+      }
+    },
+    {
+      "name": "Currency",
+      "type": "string",
+      "default": "EUR"
+    },
+    {
+      "name": "Timestamp",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-millis"
+      }
+    },
+    {
+      "name": "Status",
+      "type": {
+        "type": "enum",
+        "name": "TransactionStatus",
+        "symbols": [ "PENDING", "COMPLETED", "FAILED" ]
+      },
+      "default": "PENDING"
+    },
+    {
+      "name": "RecipientId",
+      "type": [ "null", "string" ],
+      "default": null
+    },
+    {
+      "name": "Metadata",
+      "type": {
+        "type": "map",
+        "values": "string"
+      },
+      "default": {}
+    },
+    {
+      "name": "Signature",
+      "type": {
+        "type": "fixed",
+        "size": 64,
+        "name": "Signature"
+      }
+    },
+    {
+      "name": "LegacyId",
+      "type": [ "null", "string" ],
+      "default": null
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Chr.Avro-based Kafka sample that starts Kafka and Schema Registry with Testcontainers
- round-trip a generated TransactionEvent through Kafka using Chr.Avro.Confluent
- document and register the new sample in the solution and README

## Testing
- dotnet build samples/AvroSourceGenerator.ChrAvroKafka/AvroSourceGenerator.ChrAvroKafka.csproj (validated in an offline sandbox using cached packages)
- dotnet run --project samples/AvroSourceGenerator.ChrAvroKafka/AvroSourceGenerator.ChrAvroKafka.csproj --no-build (blocked in sandbox because Docker access to npipe://./pipe/docker_engine was denied)