### PR TITLE
Refactor annotation parsing and improve identifier handling

### DIFF
--- a/src/AvroSourceGenerator.Core/Avdl/Parser.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Parser.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Immutable;
 using AvroSourceGenerator.Avdl.Syntax;
+using AvroSourceGenerator.Avdl.Syntax.Annotations;
 using AvroSourceGenerator.Avdl.Syntax.Declarations;
 using AvroSourceGenerator.Avdl.Syntax.Directives;
 using AvroSourceGenerator.Avdl.Syntax.Types;
@@ -9,7 +10,7 @@ namespace AvroSourceGenerator.Avdl;
 public sealed class Parser(SourceText sourceText)
 {
     private readonly SyntaxTokenStream _stream = new(sourceText);
-    private readonly List<AnnotationSyntax> _annotations = [];
+    private readonly List<IAnnotationSyntax> _annotations = [];
     private readonly List<DocumentationSyntax> _documentation = [];
 
     public static CompilationUnitSyntax Parse(SourceText sourceText)
@@ -107,11 +108,11 @@ public sealed class Parser(SourceText sourceText)
         }
     }
 
-    private (SyntaxList<DocumentationSyntax> Documentation, SyntaxList<AnnotationSyntax> Annotations) DequeueMetadata()
+    private (SyntaxList<DocumentationSyntax> Documentation, SyntaxList<IAnnotationSyntax> Annotations) DequeueMetadata()
     {
         var documentation = new SyntaxList<DocumentationSyntax>([.. _documentation]);
         _documentation.Clear();
-        var annotations = new SyntaxList<AnnotationSyntax>([.. _annotations]);
+        var annotations = new SyntaxList<IAnnotationSyntax>([.. _annotations]);
         _annotations.Clear();
         return (documentation, annotations);
     }
@@ -122,14 +123,21 @@ public sealed class Parser(SourceText sourceText)
         return new DocumentationSyntax(documentationTrivia);
     }
 
-    private AnnotationSyntax ParseAnnotation()
+    private IAnnotationSyntax ParseAnnotation()
     {
         var atSignToken = _stream.Match(SyntaxKind.AtSignToken);
-        var name = SyntaxFacts.GetKeywordKind(_stream.Current.SourceSpan.Text) is not SyntaxKind.IdentifierToken ? _stream.Next() : _stream.Match(SyntaxKind.IdentifierToken);
+        var name = _stream.Current.SyntaxKind is SyntaxKind.NamespaceKeyword ? _stream.Next() : _stream.Match(SyntaxKind.IdentifierToken);
         var parenthesisOpenToken = _stream.Match(SyntaxKind.ParenthesisOpenToken);
         var jsonValue = ParseJsonValue();
         var parenthesisCloseToken = _stream.Match(SyntaxKind.ParenthesisCloseToken);
-        return new AnnotationSyntax(atSignToken, name, parenthesisOpenToken, jsonValue, parenthesisCloseToken);
+        return name switch
+        {
+            { SyntaxKind: SyntaxKind.NamespaceKeyword } => new NamespaceAnnotationSyntax(atSignToken, name, parenthesisOpenToken, jsonValue, parenthesisCloseToken),
+            { ValueText: "aliases" } => new AliasesAnnotationSyntax(atSignToken, name, parenthesisOpenToken, jsonValue, parenthesisCloseToken),
+            { ValueText: "order" } => new OrderAnnotationSyntax(atSignToken, name, parenthesisOpenToken, jsonValue, parenthesisCloseToken),
+
+            _ => new CustomAnnotationSyntax(atSignToken, name, parenthesisOpenToken, jsonValue, parenthesisCloseToken),
+        };
     }
 
     private JsonValueSyntax ParseJsonValue()

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Annotations/AliasesAnnotationSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Annotations/AliasesAnnotationSyntax.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Immutable;
+
+namespace AvroSourceGenerator.Avdl.Syntax.Annotations;
+
+public sealed record class AliasesAnnotationSyntax(
+    SyntaxToken AtSignToken,
+    SyntaxToken AliasesIdentifier,
+    SyntaxToken ParenthesisOpenToken,
+    JsonValueSyntax JsonValue,
+    SyntaxToken ParenthesisCloseToken)
+    : IAnnotationSyntax
+{
+    public SyntaxKind SyntaxKind => SyntaxKind.AliasesAnnotation;
+
+    public ImmutableArray<string> Aliases => !field.IsDefault ? field : field = JsonValue.JsonNode?.AsArray().GetValues<string>().ToImmutableArray() ?? [];
+
+    public IEnumerable<ISyntaxNode> Children()
+    {
+        yield return AtSignToken;
+        yield return AliasesIdentifier;
+        yield return ParenthesisOpenToken;
+        yield return JsonValue;
+        yield return ParenthesisCloseToken;
+    }
+}

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Annotations/CustomAnnotationSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Annotations/CustomAnnotationSyntax.cs
@@ -1,21 +1,21 @@
-﻿namespace AvroSourceGenerator.Avdl.Syntax;
+﻿namespace AvroSourceGenerator.Avdl.Syntax.Annotations;
 
-public sealed record class AnnotationSyntax(
+public sealed record class CustomAnnotationSyntax(
     SyntaxToken AtSignToken,
     SyntaxToken NameIdentifier,
     SyntaxToken ParenthesisOpenToken,
-    JsonValueSyntax? Json,
+    JsonValueSyntax JsonValue,
     SyntaxToken ParenthesisCloseToken)
-    : ISyntaxNode
+    : IAnnotationSyntax
 {
-    public SyntaxKind SyntaxKind => SyntaxKind.Annotation;
+    public SyntaxKind SyntaxKind => SyntaxKind.CustomAnnotation;
 
     public IEnumerable<ISyntaxNode> Children()
     {
         yield return AtSignToken;
         yield return NameIdentifier;
         yield return ParenthesisOpenToken;
-        if (Json is not null) yield return Json;
+        yield return JsonValue;
         yield return ParenthesisCloseToken;
     }
 }

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Annotations/IAnnotationSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Annotations/IAnnotationSyntax.cs
@@ -1,0 +1,6 @@
+﻿namespace AvroSourceGenerator.Avdl.Syntax.Annotations;
+
+public interface IAnnotationSyntax : ISyntaxNode
+{
+    public JsonValueSyntax JsonValue { get; }
+}

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Annotations/NamespaceAnnotationSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Annotations/NamespaceAnnotationSyntax.cs
@@ -1,0 +1,23 @@
+﻿namespace AvroSourceGenerator.Avdl.Syntax.Annotations;
+
+public sealed record class NamespaceAnnotationSyntax(
+    SyntaxToken AtSignToken,
+    SyntaxToken NamespaceKeyword,
+    SyntaxToken ParenthesisOpenToken,
+    JsonValueSyntax JsonValue,
+    SyntaxToken ParenthesisCloseToken)
+    : IAnnotationSyntax
+{
+    public SyntaxKind SyntaxKind => SyntaxKind.NamespaceAnnotation;
+
+    public string Namespace => field ??= JsonValue.JsonNode?.AsValue().GetValue<string>() ?? string.Empty;
+
+    public IEnumerable<ISyntaxNode> Children()
+    {
+        yield return AtSignToken;
+        yield return NamespaceKeyword;
+        yield return ParenthesisOpenToken;
+        yield return JsonValue;
+        yield return ParenthesisCloseToken;
+    }
+}

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Annotations/OrderAnnotationSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Annotations/OrderAnnotationSyntax.cs
@@ -1,0 +1,24 @@
+﻿namespace AvroSourceGenerator.Avdl.Syntax.Annotations;
+
+public sealed record class OrderAnnotationSyntax(
+    SyntaxToken AtSignToken,
+    SyntaxToken OrderIdentifier,
+    SyntaxToken ParenthesisOpenToken,
+    JsonValueSyntax JsonValue,
+    SyntaxToken ParenthesisCloseToken)
+    : IAnnotationSyntax
+{
+    public SyntaxKind SyntaxKind => SyntaxKind.OrderAnnotation;
+
+    // TODO: We probably want to validate that only 'ascending', 'descending' and 'ignore' are allowed.
+    public string Order => field ??= JsonValue.JsonNode?.GetValue<string>() ?? "ignore";
+
+    public IEnumerable<ISyntaxNode> Children()
+    {
+        yield return AtSignToken;
+        yield return OrderIdentifier;
+        yield return ParenthesisOpenToken;
+        yield return JsonValue;
+        yield return ParenthesisCloseToken;
+    }
+}

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/EnumDeclarationSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/EnumDeclarationSyntax.cs
@@ -1,10 +1,12 @@
-﻿namespace AvroSourceGenerator.Avdl.Syntax.Declarations;
+﻿using AvroSourceGenerator.Avdl.Syntax.Annotations;
+
+namespace AvroSourceGenerator.Avdl.Syntax.Declarations;
 
 public sealed record class EnumDeclarationSyntax(
     SyntaxToken EnumKeyword,
     SimpleNameSyntax Name,
     SyntaxList<DocumentationSyntax> Documentation,
-    SyntaxList<AnnotationSyntax> Annotations,
+    SyntaxList<IAnnotationSyntax> Annotations,
     SyntaxToken BraceOpenToken,
     SeparatedSyntaxList<SimpleNameSyntax> Symbols,
     SyntaxToken BraceCloseToken,

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/ErrorDeclarationSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/ErrorDeclarationSyntax.cs
@@ -1,10 +1,12 @@
-﻿namespace AvroSourceGenerator.Avdl.Syntax.Declarations;
+﻿using AvroSourceGenerator.Avdl.Syntax.Annotations;
+
+namespace AvroSourceGenerator.Avdl.Syntax.Declarations;
 
 public sealed record class ErrorDeclarationSyntax(
     SyntaxToken ErrorKeyword,
     SimpleNameSyntax Name,
     SyntaxList<DocumentationSyntax> Documentation,
-    SyntaxList<AnnotationSyntax> Annotations,
+    SyntaxList<IAnnotationSyntax> Annotations,
     SyntaxToken BraceOpenToken,
     SyntaxList<FieldDeclarationSyntax> Fields,
     SyntaxToken BraceCloseToken)

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/FieldDeclarationSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/FieldDeclarationSyntax.cs
@@ -1,4 +1,5 @@
-﻿using AvroSourceGenerator.Avdl.Syntax.Types;
+﻿using AvroSourceGenerator.Avdl.Syntax.Annotations;
+using AvroSourceGenerator.Avdl.Syntax.Types;
 
 namespace AvroSourceGenerator.Avdl.Syntax.Declarations;
 
@@ -6,7 +7,7 @@ public sealed record class FieldDeclarationSyntax(
     ITypeSyntax Type,
     SimpleNameSyntax Name,
     SyntaxList<DocumentationSyntax> Documentation,
-    SyntaxList<AnnotationSyntax> Annotations,
+    SyntaxList<IAnnotationSyntax> Annotations,
     DefaultValueClauseSyntax? DefaultValueClause,
     SyntaxToken SemicolonToken)
     : ISyntaxNode

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/FixedDeclarationSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/FixedDeclarationSyntax.cs
@@ -1,10 +1,12 @@
-﻿namespace AvroSourceGenerator.Avdl.Syntax.Declarations;
+﻿using AvroSourceGenerator.Avdl.Syntax.Annotations;
+
+namespace AvroSourceGenerator.Avdl.Syntax.Declarations;
 
 public sealed record class FixedDeclarationSyntax(
     SyntaxToken FixedKeyword,
     SimpleNameSyntax Name,
     SyntaxList<DocumentationSyntax> Documentation,
-    SyntaxList<AnnotationSyntax> Annotations,
+    SyntaxList<IAnnotationSyntax> Annotations,
     SyntaxToken ParenthesisOpenToken,
     SyntaxToken SizeLiteralToken,
     SyntaxToken ParenthesisCloseToken,

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/ProtocolDeclarationSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/ProtocolDeclarationSyntax.cs
@@ -1,10 +1,12 @@
-﻿namespace AvroSourceGenerator.Avdl.Syntax.Declarations;
+﻿using AvroSourceGenerator.Avdl.Syntax.Annotations;
+
+namespace AvroSourceGenerator.Avdl.Syntax.Declarations;
 
 public sealed record class ProtocolDeclarationSyntax(
     SyntaxToken ProtocolKeyword,
     SimpleNameSyntax Name,
     SyntaxList<DocumentationSyntax> Documentation,
-    SyntaxList<AnnotationSyntax> Annotations,
+    SyntaxList<IAnnotationSyntax> Annotations,
     SyntaxToken BraceOpenToken,
     SyntaxList<ISchemaDeclarationSyntax> Types,
     SyntaxList<MessageDeclarationSyntax> Messages,

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/RecordDeclarationSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/RecordDeclarationSyntax.cs
@@ -1,10 +1,12 @@
-﻿namespace AvroSourceGenerator.Avdl.Syntax.Declarations;
+﻿using AvroSourceGenerator.Avdl.Syntax.Annotations;
+
+namespace AvroSourceGenerator.Avdl.Syntax.Declarations;
 
 public sealed record class RecordDeclarationSyntax(
     SyntaxToken RecordKeyword,
     SimpleNameSyntax Name,
     SyntaxList<DocumentationSyntax> Documentation,
-    SyntaxList<AnnotationSyntax> Annotations,
+    SyntaxList<IAnnotationSyntax> Annotations,
     SyntaxToken BraceOpenToken,
     SyntaxList<FieldDeclarationSyntax> Fields,
     SyntaxToken BraceCloseToken)

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/JsonParser.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/JsonParser.cs
@@ -90,7 +90,7 @@ internal readonly ref struct JsonParser(SyntaxTokenStream stream)
             _ = stream.Match(SyntaxKind.ColonToken);
             var propertyValue = ParseJson();
 
-            @object.Add((string?)propertyName.Value ?? propertyName.SourceSpan.ToString(), propertyValue);
+            @object.Add((string?)propertyName.Value ?? propertyName.ValueText, propertyValue);
             if (stream.Current.SyntaxKind is not SyntaxKind.CommaToken)
                 break;
 
@@ -105,6 +105,6 @@ internal readonly ref struct JsonParser(SyntaxTokenStream stream)
     private JsonValue ParseSymbol()
     {
         var symbolToken = stream.Match(SyntaxKind.IdentifierToken);
-        return JsonValue.Create(symbolToken.SourceSpan.ToString());
+        return JsonValue.Create(symbolToken.ValueText);
     }
 }

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/JsonValueSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/JsonValueSyntax.cs
@@ -2,7 +2,7 @@
 
 namespace AvroSourceGenerator.Avdl.Syntax;
 
-public sealed record class JsonValueSyntax(SyntaxList<SyntaxToken> SyntaxTokens, JsonNode? Json) : ISyntaxNode
+public sealed record class JsonValueSyntax(SyntaxList<SyntaxToken> SyntaxTokens, JsonNode? JsonNode) : ISyntaxNode
 {
     public SyntaxKind SyntaxKind => SyntaxKind.JsonValue;
 

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/QualifiedNameSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/QualifiedNameSyntax.cs
@@ -4,7 +4,7 @@ public sealed record class QualifiedNameSyntax(SeparatedSyntaxList<SyntaxToken> 
 {
     public SyntaxKind SyntaxKind => SyntaxKind.QualifiedName;
 
-    public string FullName => field ??= string.Concat(Identifiers.SyntaxNodes.Select(n => (n as SyntaxToken)?.SourceSpan.ToString() ?? SyntaxFacts.GetText(n.SyntaxKind)));
+    public string FullName => field ??= string.Concat(Identifiers.SyntaxNodes.Select(n => (n as SyntaxToken)?.ValueText ?? SyntaxFacts.GetText(n.SyntaxKind)));
 
     public IEnumerable<ISyntaxNode> Children() => Identifiers.SyntaxNodes;
 }

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Scanner.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Scanner.cs
@@ -7,6 +7,7 @@ public sealed class Scanner(SourceText sourceText)
 {
     private readonly List<SyntaxToken> _badTokens = [];
     private int _position = 0;
+    private SyntaxToken? _previousSyntaxToken = null;
 
     private ReadOnlySpan<char> CurrentSpan => sourceText.Text.AsSpan(_position);
 
@@ -28,7 +29,7 @@ public sealed class Scanner(SourceText sourceText)
         while (true)
         {
             _position += SyntaxTriviaScanner.Skip(CurrentSpan);
-            var syntaxToken = ScanAny();
+            var syntaxToken = _previousSyntaxToken = ScanAny();
             _position += syntaxToken.SourceSpan.Length;
 
             if (syntaxToken.SyntaxKind is not SyntaxKind.InvalidSyntax)
@@ -102,12 +103,9 @@ public sealed class Scanner(SourceText sourceText)
             case ['-', '.', var d4, ..] when IsAsciiDigit(d4):
                 return ScanNumber();
 
-            case ['_', ..]:
-            case [var l, ..] when IsAsciiLetter(l):
+            case [var l1, ..] when IsIdentifierStart(l1):
+            case ['`', var l2, ..] when IsIdentifierStart(l2):
                 return ScanIdentifier();
-
-            case ['`', ..]:
-                return ScanIdentifierVerbatim();
 
             // Control
             case []:
@@ -253,11 +251,11 @@ public sealed class Scanner(SourceText sourceText)
             }
         }
 
-        if (length < CurrentSpan.Length && (CurrentSpan[length] is 'e' or 'E'))
+        if (length < CurrentSpan.Length && CurrentSpan[length] is 'e' or 'E')
         {
             isFloat = true;
             ++length;
-            if (length < CurrentSpan.Length && (CurrentSpan[length] is '+' or '-'))
+            if (length < CurrentSpan.Length && CurrentSpan[length] is '+' or '-')
                 ++length;
 
             var exponentDigitsStart = length;
@@ -321,54 +319,66 @@ public sealed class Scanner(SourceText sourceText)
         return length;
     }
 
-    private static bool IsAsciiLetter(char c) => (uint)((c | 0x20) - 'a') <= 'z' - 'a';
-
     private SyntaxToken ScanIdentifier()
     {
-        var length = GetIdentifierLength(CurrentSpan);
-        var syntaxKind = SyntaxFacts.GetKeywordKind(CurrentSpan[..length]);
-        object? value = syntaxKind switch
-        {
-            SyntaxKind.TrueKeyword => true,
-            SyntaxKind.FalseKeyword => false,
-            _ => null,
-        };
-
-        return new SyntaxToken(syntaxKind, new SourceSpan(sourceText, _position, length), value);
-    }
-
-    private SyntaxToken ScanIdentifierVerbatim()
-    {
         var start = _position;
-        var identifierStart = start + 1;
-        var identifierSpan = sourceText.Text.AsSpan(identifierStart);
+        var isVerbatim = CurrentSpan is ['`', ..];
+
+        var identifierSpan = isVerbatim ? CurrentSpan[1..] : CurrentSpan;
+
         if (identifierSpan.IsEmpty || !IsIdentifierStart(identifierSpan[0]))
         {
             return new SyntaxToken(SyntaxKind.InvalidSyntax, new SourceSpan(sourceText, start, 1));
         }
 
-        var length = GetIdentifierLength(identifierSpan);
-        if (identifierSpan.Length == length || identifierSpan[length] is not '`')
+        var length = GetIdentifierLength(identifierSpan, _previousSyntaxToken?.SyntaxKind is SyntaxKind.AtSignToken);
+
+        if (isVerbatim)
         {
-            return new SyntaxToken(SyntaxKind.InvalidSyntax, new SourceSpan(sourceText, start, Math.Min(sourceText.Text.Length - start, length + 1)));
+            if (length >= identifierSpan.Length || identifierSpan[length] is not '`')
+            {
+                return new SyntaxToken(
+                    SyntaxKind.InvalidSyntax,
+                    new SourceSpan(
+                        sourceText,
+                        start,
+                        Math.Min(sourceText.Text.Length - start, length + 1)));
+            }
+
+            return new SyntaxToken(
+                SyntaxKind.IdentifierToken,
+                new SourceSpan(sourceText, start, length + 2),
+                identifierSpan[..length].ToString());
         }
 
-        _position += 2; // Skip both backticks. Scan() advances over the identifier text.
-        return new SyntaxToken(SyntaxKind.IdentifierToken, new SourceSpan(sourceText, identifierStart, length), identifierSpan[..length].ToString());
+        var text = identifierSpan[..length];
+        var kind = SyntaxFacts.GetKeywordKind(text);
+
+        object? value = kind switch
+        {
+            SyntaxKind.TrueKeyword => true,
+            SyntaxKind.FalseKeyword => false,
+            SyntaxKind.IdentifierToken => text.ToString(),
+            _ => null,
+        };
+
+        return new SyntaxToken(kind, new SourceSpan(sourceText, start, length), value);
     }
 
-    private static int GetIdentifierLength(ReadOnlySpan<char> chars)
+    private static int GetIdentifierLength(ReadOnlySpan<char> chars, bool allowDash)
     {
         var length = 0;
-        while (length < chars.Length && IsValid(chars[length]))
+        while (length < chars.Length && IsValid(chars[length], allowDash))
         {
             length++;
         }
 
         return length;
 
-        static bool IsValid(char c) => c is '_' || IsAsciiDigit(c) || IsAsciiLetter(c);
+        static bool IsValid(char c, bool allowDash) => c is '_' || IsAsciiDigit(c) || IsAsciiLetter(c) || (allowDash && c == '-');
     }
 
     private static bool IsIdentifierStart(char c) => c is '_' || IsAsciiLetter(c);
+
+    private static bool IsAsciiLetter(char c) => (uint)((c | 0x20) - 'a') <= 'z' - 'a';
 }

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/SimpleNameSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/SimpleNameSyntax.cs
@@ -4,7 +4,7 @@ public sealed record class SimpleNameSyntax(SyntaxToken Identifier) : INameSynta
 {
     public SyntaxKind SyntaxKind => SyntaxKind.SimpleName;
 
-    public string FullName => field ??= Identifier.SourceSpan.ToString();
+    public string FullName => field ??= Identifier.ValueText;
 
     public IEnumerable<ISyntaxNode> Children()
     {

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/SyntaxFacts.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/SyntaxFacts.cs
@@ -97,11 +97,16 @@ public static class SyntaxFacts
             SyntaxKind.OptionalType => null,
             SyntaxKind.NamedType => null,
 
-            SyntaxKind.Annotation => null,
-            SyntaxKind.Documentation => null,
             SyntaxKind.NamespaceDirective => null,
             SyntaxKind.SchemaDirective => null,
             SyntaxKind.ImportDirective => null,
+
+            SyntaxKind.Documentation => null,
+
+            SyntaxKind.NamespaceAnnotation => null,
+            SyntaxKind.AliasesAnnotation => null,
+            SyntaxKind.OrderAnnotation => null,
+            SyntaxKind.CustomAnnotation => null,
 
             SyntaxKind.EnumDeclaration => null,
             SyntaxKind.RecordDeclaration => null,

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/SyntaxKind.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/SyntaxKind.cs
@@ -45,6 +45,13 @@ public enum SyntaxKind
     DoubleKeyword,
     BytesKeyword,
 
+    DecimalKeyword,
+    DateKeyword,
+    TimeMsKeyword,
+    TimestampMsKeyword,
+    LocalTimestampMsKeyword,
+    UuidKeyword,
+
     ArrayKeyword,
     MapKeyword,
     UnionKeyword,
@@ -60,13 +67,6 @@ public enum SyntaxKind
     ImportKeyword,
     IdlKeyword,
     TypedefKeyword,
-
-    DecimalKeyword,
-    DateKeyword,
-    TimeMsKeyword,
-    TimestampMsKeyword,
-    LocalTimestampMsKeyword,
-    UuidKeyword,
 
     ThrowsKeyword,
     OneWayKeyword,
@@ -103,8 +103,12 @@ public enum SyntaxKind
     SchemaDirective,
     ImportDirective,
 
-    Annotation,
     Documentation,
+
+    NamespaceAnnotation,
+    AliasesAnnotation,
+    OrderAnnotation,
+    CustomAnnotation,
 
     EnumDeclaration,
     RecordDeclaration,

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/SyntaxToken.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/SyntaxToken.cs
@@ -2,11 +2,12 @@
 
 public readonly record struct SourceSpan(SourceText SourceText, int Offset, int Length)
 {
-    public ReadOnlySpan<char> Text => SourceText.Text.AsSpan(Offset, Length);
-    public override string ToString() => Text.ToString();
+    public override string ToString() => SourceText.Text.AsSpan(Offset, Length).ToString();
 }
 
 public sealed record class SyntaxToken(SyntaxKind SyntaxKind, SourceSpan SourceSpan, object? Value = null) : ISyntaxNode
 {
+    public string ValueText => Value?.ToString() ?? SourceSpan.ToString();
+
     public IEnumerable<ISyntaxNode> Children() => [];
 }

--- a/tests/AvroSourceGenerator.Tests/Avdl/ParserTests.cs
+++ b/tests/AvroSourceGenerator.Tests/Avdl/ParserTests.cs
@@ -1,5 +1,6 @@
-using AvroSourceGenerator.Avdl;
+﻿using AvroSourceGenerator.Avdl;
 using AvroSourceGenerator.Avdl.Syntax;
+using AvroSourceGenerator.Avdl.Syntax.Annotations;
 using AvroSourceGenerator.Avdl.Syntax.Declarations;
 using AvroSourceGenerator.Avdl.Syntax.Directives;
 using AvroSourceGenerator.Avdl.Syntax.Types;
@@ -11,7 +12,8 @@ public sealed class ParserTests
     [Fact]
     public void Parse_DirectivesAndProtocol_ReturnsCompilationUnit()
     {
-        var unit = Parse("""
+        var unit = Parse(
+            """
             namespace example.avro;
             schema Main;
             import idl "dep.avdl";
@@ -43,7 +45,8 @@ public sealed class ParserTests
     [Fact]
     public void Parse_TopLevelDeclarations_ReturnsDeclarationShapesAndMetadata()
     {
-        var unit = Parse("""
+        var unit = Parse(
+            """
             /** Kind doc */
             @aliases(["OldKind", "OlderKind"])
             enum Kind { A, B } = A;
@@ -66,9 +69,11 @@ public sealed class ParserTests
         var enumDeclaration = Assert.IsType<EnumDeclarationSyntax>(unit.Declarations[0]);
         Assert.Equal("Kind", enumDeclaration.Name.Identifier.SourceSpan.ToString());
         Assert.Equal(" Kind doc ", Assert.Single(enumDeclaration.Documentation).DocumentationTrivia.SourceSpan.ToString());
-        Assert.Equal(2, Assert.IsType<JsonArray>(Assert.Single(enumDeclaration.Annotations).Json!.Json).Count);
+        var aliases = Assert.IsType<AliasesAnnotationSyntax>(Assert.Single(enumDeclaration.Annotations));
+        Assert.Equal(["OldKind", "OlderKind"], aliases.Aliases);
+        Assert.Equal(2, Assert.IsType<JsonArray>(aliases.JsonValue.JsonNode).Count);
         Assert.Equal(2, enumDeclaration.Symbols.Count);
-        Assert.Equal("A", enumDeclaration.DefaultValue!.JsonValue.Json!.GetValue<string>());
+        Assert.Equal("A", enumDeclaration.DefaultValue!.JsonValue.JsonNode?.GetValue<string>());
 
         var fixedDeclaration = Assert.IsType<FixedDeclarationSyntax>(unit.Declarations[1]);
         Assert.Equal("MD5", fixedDeclaration.Name.Identifier.SourceSpan.ToString());
@@ -85,14 +90,15 @@ public sealed class ParserTests
         var nameField = recordDeclaration.Fields[0];
         Assert.Equal(SyntaxKind.StringType, nameField.Type.SyntaxKind);
         Assert.Equal("name", nameField.Name.Identifier.SourceSpan.ToString());
-        Assert.Equal("ignore", Assert.Single(nameField.Annotations).Json!.Json!.GetValue<string>());
-        Assert.Equal("Ada", nameField.DefaultValueClause!.JsonValue.Json!.GetValue<string>());
+        var order = Assert.IsType<OrderAnnotationSyntax>(Assert.Single(nameField.Annotations));
+        Assert.Equal("ignore", order.Order);
+        Assert.Equal("Ada", nameField.DefaultValueClause!.JsonValue.JsonNode?.GetValue<string>());
 
         var resultCodeField = recordDeclaration.Fields[1];
         Assert.Equal("result_code", resultCodeField.Name.Identifier.SourceSpan.ToString());
-        Assert.Equal(-1, resultCodeField.DefaultValueClause!.JsonValue.Json!.GetValue<int>());
+        Assert.Equal(-1, resultCodeField.DefaultValueClause!.JsonValue.JsonNode?.GetValue<int>());
 
-        var configDefault = Assert.IsType<JsonObject>(recordDeclaration.Fields[2].DefaultValueClause!.JsonValue.Json);
+        var configDefault = Assert.IsType<JsonObject>(recordDeclaration.Fields[2].DefaultValueClause!.JsonValue.JsonNode);
         Assert.Equal(1, configDefault["x"]!.GetValue<int>());
         Assert.True(configDefault["ok"]!.GetValue<bool>());
         Assert.Equal("b", Assert.IsType<JsonArray>(configDefault["tags"]).Last()!.GetValue<string>());
@@ -105,7 +111,8 @@ public sealed class ParserTests
     [Fact]
     public void Parse_Protocol_ReturnsTypesMessagesAndClauses()
     {
-        var unit = Parse("""
+        var unit = Parse(
+            """
             @namespace("example")
             protocol Service {
                 enum Kind { A }
@@ -128,7 +135,8 @@ public sealed class ParserTests
 
         var protocol = Assert.IsType<ProtocolDeclarationSyntax>(Assert.Single(unit.Declarations));
         Assert.Equal("Service", protocol.Name.Identifier.SourceSpan.ToString());
-        Assert.Equal("example", Assert.Single(protocol.Annotations).Json!.Json!.GetValue<string>());
+        var namespaceAnnotation = Assert.IsType<NamespaceAnnotationSyntax>(Assert.Single(protocol.Annotations));
+        Assert.Equal("example", namespaceAnnotation.Namespace);
         Assert.Equal(4, protocol.Types.Count);
         Assert.Equal(2, protocol.Messages.Count);
 
@@ -151,14 +159,15 @@ public sealed class ParserTests
         Assert.Equal("hello", hello.Name.Identifier.SourceSpan.ToString());
         Assert.Equal(2, hello.Parameters.Count);
         Assert.Equal("greeting", hello.Parameters[0].Name.Identifier.SourceSpan.ToString());
-        Assert.Equal(1, hello.Parameters[1].DefaultValueClause!.JsonValue.Json!.GetValue<int>());
+        Assert.Equal(1, hello.Parameters[1].DefaultValueClause!.JsonValue.JsonNode?.GetValue<int>());
         Assert.Equal(2, hello.ThrowsErrorClause!.Errors.Count);
     }
 
     [Fact]
     public void Parse_VerbatimIdentifiers_AllowsKeywordsAsNames()
     {
-        var unit = Parse("""
+        var unit = Parse(
+            """
             protocol P {
                 void `error`(string `record`);
             }
@@ -166,8 +175,27 @@ public sealed class ParserTests
 
         var message = Assert.IsType<ProtocolDeclarationSyntax>(Assert.Single(unit.Declarations)).Messages[0];
 
-        Assert.Equal("error", message.Name.Identifier.SourceSpan.ToString());
-        Assert.Equal("record", message.Parameters[0].Name.Identifier.SourceSpan.ToString());
+        Assert.Equal("`error`", message.Name.Identifier.SourceSpan.ToString());
+        Assert.Equal("error", message.Name.FullName);
+        Assert.Equal("error", message.Name.Identifier.ValueText);
+        Assert.Equal("`record`", message.Parameters[0].Name.Identifier.SourceSpan.ToString());
+        Assert.Equal("record", message.Parameters[0].Name.FullName);
+    }
+
+    [Fact]
+    public void Parse_CustomAnnotation_AllowsDashInName()
+    {
+        var unit = Parse(
+            """
+            @java-class("com.example.User")
+            record User {}
+            """);
+
+        var record = Assert.IsType<RecordDeclarationSyntax>(Assert.Single(unit.Declarations));
+        var annotation = Assert.IsType<CustomAnnotationSyntax>(Assert.Single(record.Annotations));
+
+        Assert.Equal("java-class", annotation.NameIdentifier.ValueText);
+        Assert.Equal("com.example.User", annotation.JsonValue.JsonNode!.GetValue<string>());
     }
 
     [Fact]

--- a/tests/AvroSourceGenerator.Tests/Avdl/ScannerTests.cs
+++ b/tests/AvroSourceGenerator.Tests/Avdl/ScannerTests.cs
@@ -123,10 +123,11 @@ public sealed class ScannerTests
         Assert.Empty(scanner.BadTokens);
         Assert.Equal(SyntaxKind.IdentifierToken, tokens[0].SyntaxKind);
         Assert.Equal("name_1", tokens[0].SourceSpan.ToString());
+        Assert.Equal("name_1", tokens[0].ValueText);
     }
 
     [Fact]
-    public void Scan_VerbatimIdentifier_ReturnsIdentifierWithoutBackticks()
+    public void Scan_VerbatimIdentifier_ReturnsIdentifierWithValueTextWithoutBackticks()
     {
         var scanner = CreateScanner("`error`");
 
@@ -134,8 +135,38 @@ public sealed class ScannerTests
 
         Assert.Empty(scanner.BadTokens);
         Assert.Equal(SyntaxKind.IdentifierToken, tokens[0].SyntaxKind);
-        Assert.Equal("error", tokens[0].SourceSpan.ToString());
+        Assert.Equal("`error`", tokens[0].SourceSpan.ToString());
         Assert.Equal("error", tokens[0].Value);
+        Assert.Equal("error", tokens[0].ValueText);
+    }
+
+    [Fact]
+    public void Scan_AnnotationIdentifier_AllowsDash()
+    {
+        var scanner = CreateScanner("@java-class(true)");
+
+        var tokens = scanner.ScanAllTokens().ToArray();
+
+        Assert.Empty(scanner.BadTokens);
+        Assert.Equal(SyntaxKind.AtSignToken, tokens[0].SyntaxKind);
+        Assert.Equal(SyntaxKind.IdentifierToken, tokens[1].SyntaxKind);
+        Assert.Equal("java-class", tokens[1].SourceSpan.ToString());
+        Assert.Equal("java-class", tokens[1].ValueText);
+    }
+
+    [Fact]
+    public void Scan_Identifier_DoesNotAllowDashOutsideAnnotationName()
+    {
+        var scanner = CreateScanner("java-class");
+
+        var tokens = scanner.ScanAllTokens().ToArray();
+
+        Assert.Single(scanner.BadTokens);
+        Assert.Equal("-", scanner.BadTokens[0].SourceSpan.ToString());
+        Assert.Equal(SyntaxKind.IdentifierToken, tokens[0].SyntaxKind);
+        Assert.Equal("java", tokens[0].ValueText);
+        Assert.Equal(SyntaxKind.IdentifierToken, tokens[1].SyntaxKind);
+        Assert.Equal("class", tokens[1].ValueText);
     }
 
     [Fact]
@@ -173,6 +204,7 @@ public sealed class ScannerTests
         Assert.Empty(scanner.BadTokens);
         Assert.Equal(SyntaxKind.StringLiteralToken, tokens[0].SyntaxKind);
         Assert.Equal("a\n\t\"\\/A", tokens[0].Value);
+        Assert.Equal("a\n\t\"\\/A", tokens[0].ValueText);
     }
 
     [Theory]


### PR DESCRIPTION
- Introduce IAnnotationSyntax and specific annotation types (Namespace, Aliases, Order, Custom).
- Update scanner to allow dashes in annotation names.
- Add SyntaxToken.ValueText so we can use it to get unescaped text, instead of dropping tokens and doing weird offset shenanigans.