### PR TITLE
Add support for imports in protocol declarations

### DIFF
--- a/src/AvroSourceGenerator.Core/Avdl/Parser.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Parser.cs
@@ -24,6 +24,7 @@ public sealed class Parser(SourceText sourceText)
     {
         var directives = ParseDirectives();
         var declarations = ParseDeclarations();
+        // TODO: Check if protocol or schema IDL and validate directives.
         return new CompilationUnitSyntax(directives, declarations);
     }
 
@@ -228,6 +229,7 @@ public sealed class Parser(SourceText sourceText)
         var name = ParseSimpleName();
         var (documentation, annotations) = DequeueMetadata();
         var braceOpenToken = _stream.Match(SyntaxKind.BraceOpenToken);
+        var imports = ImmutableArray.CreateBuilder<ImportDirectiveSyntax>();
         var types = ImmutableArray.CreateBuilder<ISchemaDeclarationSyntax>();
         var messages = ImmutableArray.CreateBuilder<MessageDeclarationSyntax>();
         while (!_stream.IsAtEnd && _stream.Current.SyntaxKind != SyntaxKind.BraceCloseToken)
@@ -235,6 +237,9 @@ public sealed class Parser(SourceText sourceText)
             EnqueueMetadata();
             switch (_stream.Current.SyntaxKind)
             {
+                case SyntaxKind.ImportKeyword:
+                    imports.Add(ParseImportDirective());
+                    break;
                 case SyntaxKind.EnumKeyword:
                     types.Add(ParseEnumDeclaration());
                     break;
@@ -261,6 +266,7 @@ public sealed class Parser(SourceText sourceText)
             documentation,
             annotations,
             braceOpenToken,
+            new SyntaxList<ImportDirectiveSyntax>(imports.ToImmutable()),
             new SyntaxList<ISchemaDeclarationSyntax>(types.ToImmutable()),
             new SyntaxList<MessageDeclarationSyntax>(messages.ToImmutable()),
             braceCloseToken);

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/ProtocolDeclarationSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/ProtocolDeclarationSyntax.cs
@@ -1,4 +1,5 @@
 ﻿using AvroSourceGenerator.Avdl.Syntax.Annotations;
+using AvroSourceGenerator.Avdl.Syntax.Directives;
 
 namespace AvroSourceGenerator.Avdl.Syntax.Declarations;
 
@@ -8,6 +9,7 @@ public sealed record class ProtocolDeclarationSyntax(
     SyntaxList<DocumentationSyntax> Documentation,
     SyntaxList<IAnnotationSyntax> Annotations,
     SyntaxToken BraceOpenToken,
+    SyntaxList<ImportDirectiveSyntax> Imports,
     SyntaxList<ISchemaDeclarationSyntax> Types,
     SyntaxList<MessageDeclarationSyntax> Messages,
     SyntaxToken BraceCloseToken)
@@ -24,6 +26,8 @@ public sealed record class ProtocolDeclarationSyntax(
         foreach (var annotation in Annotations)
             yield return annotation;
         yield return BraceOpenToken;
+        foreach (var import in Imports)
+            yield return import;
         foreach (var type in Types)
             yield return type;
         foreach (var message in Messages)

--- a/tests/AvroSourceGenerator.Tests/Avdl/ParserTests.cs
+++ b/tests/AvroSourceGenerator.Tests/Avdl/ParserTests.cs
@@ -38,8 +38,51 @@ public sealed class ParserTests
         Assert.Equal(SyntaxKind.SchemaKeyword, schemaImport.ImportTypeKeyword.SyntaxKind);
         Assert.Equal("dep.avsc", schemaImport.ImportPathLiteralToken.Value);
 
-        var protocol = Assert.Single(unit.Declarations);
-        Assert.Equal("P", Assert.IsType<ProtocolDeclarationSyntax>(protocol).Name.Identifier.SourceSpan.ToString());
+        var protocol = Assert.IsType<ProtocolDeclarationSyntax>(Assert.Single(unit.Declarations));
+        Assert.Equal("P", protocol.Name.Identifier.SourceSpan.ToString());
+        Assert.Empty(protocol.Imports);
+    }
+
+    [Fact]
+    public void Parse_ProtocolImports_ReturnsImportsOnProtocol()
+    {
+        var unit = Parse(
+            """
+            protocol P {
+                import idl "common.avdl";
+                import protocol "dep.avpr";
+                import schema "dep.avsc";
+
+                record Request {
+                    string name;
+                }
+
+                void ping();
+            }
+            """);
+
+        Assert.Empty(unit.Directives);
+
+        var protocol = Assert.IsType<ProtocolDeclarationSyntax>(Assert.Single(unit.Declarations));
+        Assert.Equal(3, protocol.Imports.Count);
+
+        var idlImport = protocol.Imports[0];
+        Assert.Equal(SyntaxKind.IdlKeyword, idlImport.ImportTypeKeyword.SyntaxKind);
+        Assert.Equal("common.avdl", idlImport.ImportPathLiteralToken.Value);
+
+        var protocolImport = protocol.Imports[1];
+        Assert.Equal(SyntaxKind.ProtocolKeyword, protocolImport.ImportTypeKeyword.SyntaxKind);
+        Assert.Equal("dep.avpr", protocolImport.ImportPathLiteralToken.Value);
+
+        var schemaImport = protocol.Imports[2];
+        Assert.Equal(SyntaxKind.SchemaKeyword, schemaImport.ImportTypeKeyword.SyntaxKind);
+        Assert.Equal("dep.avsc", schemaImport.ImportPathLiteralToken.Value);
+
+        Assert.Single(protocol.Types);
+        Assert.Single(protocol.Messages);
+
+        var kinds = AvdlTestHelpers.FlattenKinds(unit);
+        Assert.Equal(3, kinds.Count(kind => kind == SyntaxKind.ImportDirective));
     }
 
     [Fact]
@@ -137,6 +180,7 @@ public sealed class ParserTests
         Assert.Equal("Service", protocol.Name.Identifier.SourceSpan.ToString());
         var namespaceAnnotation = Assert.IsType<NamespaceAnnotationSyntax>(Assert.Single(protocol.Annotations));
         Assert.Equal("example", namespaceAnnotation.Namespace);
+        Assert.Empty(protocol.Imports);
         Assert.Equal(4, protocol.Types.Count);
         Assert.Equal(2, protocol.Messages.Count);
 


### PR DESCRIPTION
Note that protocol IDL only supports imports inside the protocol declaration. We'll leave the parser permissive and validate later.