### PR TITLE
Refactor parser: use DocumentSyntax & add SyntaxTree/diagnostics

### DIFF
--- a/src/AvroSourceGenerator.Core/Avdl/Diagnostics/SyntaxDiagnostic.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Diagnostics/SyntaxDiagnostic.cs
@@ -1,0 +1,10 @@
+﻿using AvroSourceGenerator.Avdl.Text;
+
+namespace AvroSourceGenerator.Avdl.Diagnostics;
+
+public enum SyntaxDiagnosticCode
+{
+    UnexpectedToken,
+}
+
+public readonly record struct SyntaxDiagnostic(SyntaxDiagnosticCode Code, SourceSpan SourceSpan, string Message);

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/DocumentSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/DocumentSyntax.cs
@@ -3,12 +3,12 @@ using AvroSourceGenerator.Avdl.Syntax.Directives;
 
 namespace AvroSourceGenerator.Avdl.Syntax;
 
-public sealed record class CompilationUnitSyntax(
+public sealed record class DocumentSyntax(
     SyntaxList<IDirectiveSyntax> Directives,
     SyntaxList<IDeclarationSyntax> Declarations
 ) : ISyntaxNode
 {
-    public SyntaxKind SyntaxKind => SyntaxKind.CompilationUnit;
+    public SyntaxKind SyntaxKind => SyntaxKind.Document;
 
     public IEnumerable<ISyntaxNode> Children()
     {

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Parser.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Parser.cs
@@ -1,32 +1,35 @@
 ﻿using System.Collections.Immutable;
-using AvroSourceGenerator.Avdl.Syntax;
+using AvroSourceGenerator.Avdl.Diagnostics;
 using AvroSourceGenerator.Avdl.Syntax.Annotations;
 using AvroSourceGenerator.Avdl.Syntax.Declarations;
 using AvroSourceGenerator.Avdl.Syntax.Directives;
 using AvroSourceGenerator.Avdl.Syntax.Types;
 using AvroSourceGenerator.Avdl.Text;
 
-namespace AvroSourceGenerator.Avdl;
+namespace AvroSourceGenerator.Avdl.Syntax;
 
 public sealed class Parser(SourceText sourceText)
 {
     private readonly SyntaxTokenStream _stream = new(sourceText);
     private readonly List<IAnnotationSyntax> _annotations = [];
     private readonly List<DocumentationSyntax> _documentation = [];
+    private readonly List<SyntaxDiagnostic> _diagnostics = [];
 
-    public static CompilationUnitSyntax Parse(SourceText sourceText)
+    public static SyntaxTree Parse(SourceText sourceText) => new Parser(sourceText).Parse();
+
+    public SyntaxTree Parse()
     {
-        // TODO: Worth to use a single instance and reset it for each file?
-        var parser = new Parser(sourceText);
-        return parser.Parse();
+        var document = ParseDocument();
+
+        return new SyntaxTree(sourceText, document, [.. _diagnostics]);
     }
 
-    private CompilationUnitSyntax Parse()
+    private DocumentSyntax ParseDocument()
     {
         var directives = ParseDirectives();
         var declarations = ParseDeclarations();
         // TODO: Check if protocol or schema IDL and validate directives.
-        return new CompilationUnitSyntax(directives, declarations);
+        return new DocumentSyntax(directives, declarations);
     }
 
     private SyntaxList<IDirectiveSyntax> ParseDirectives()

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/SyntaxFacts.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/SyntaxFacts.cs
@@ -76,7 +76,7 @@ public static class SyntaxFacts
             SyntaxKind.InvalidTextTrivia => null,
             SyntaxKind.DocumentationTrivia => null,
 
-            SyntaxKind.CompilationUnit => null,
+            SyntaxKind.Document => null,
 
             SyntaxKind.SimpleName => null,
             SyntaxKind.QualifiedName => null,

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/SyntaxKind.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/SyntaxKind.cs
@@ -78,7 +78,7 @@ public enum SyntaxKind
     InvalidTextTrivia,
     DocumentationTrivia,
 
-    CompilationUnit,
+    Document,
 
     SimpleName,
     QualifiedName,

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/SyntaxTree.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/SyntaxTree.cs
@@ -1,0 +1,7 @@
+﻿using System.Collections.Immutable;
+using AvroSourceGenerator.Avdl.Diagnostics;
+using AvroSourceGenerator.Avdl.Text;
+
+namespace AvroSourceGenerator.Avdl.Syntax;
+
+public sealed record class SyntaxTree(SourceText SourceText, DocumentSyntax Document, ImmutableArray<SyntaxDiagnostic> Diagnostics);

--- a/tests/AvroSourceGenerator.Tests/Avdl/ParserTests.cs
+++ b/tests/AvroSourceGenerator.Tests/Avdl/ParserTests.cs
@@ -1,5 +1,4 @@
-﻿using AvroSourceGenerator.Avdl;
-using AvroSourceGenerator.Avdl.Syntax;
+﻿using AvroSourceGenerator.Avdl.Syntax;
 using AvroSourceGenerator.Avdl.Syntax.Annotations;
 using AvroSourceGenerator.Avdl.Syntax.Declarations;
 using AvroSourceGenerator.Avdl.Syntax.Directives;
@@ -10,7 +9,7 @@ namespace AvroSourceGenerator.Tests.Avdl;
 public sealed class ParserTests
 {
     [Fact]
-    public void Parse_DirectivesAndProtocol_ReturnsCompilationUnit()
+    public void Parse_DirectivesAndProtocol_ReturnsDocument()
     {
         var unit = Parse(
             """
@@ -325,7 +324,7 @@ public sealed class ParserTests
 
         var kinds = AvdlTestHelpers.FlattenKinds(unit);
 
-        Assert.Contains(SyntaxKind.CompilationUnit, kinds);
+        Assert.Contains(SyntaxKind.Document, kinds);
         Assert.Contains(SyntaxKind.RecordDeclaration, kinds);
         Assert.Contains(SyntaxKind.FieldDeclaration, kinds);
         Assert.Contains(SyntaxKind.StringType, kinds);
@@ -338,5 +337,5 @@ public sealed class ParserTests
         Assert.Equal(logicalTypeKeyword, logicalType.LogicalTypeNameKeyword.SyntaxKind);
     }
 
-    private static CompilationUnitSyntax Parse(string text) => Parser.Parse(AvdlTestHelpers.SourceText(text));
+    private static DocumentSyntax Parse(string text) => Parser.Parse(AvdlTestHelpers.SourceText(text)).Document;
 }


### PR DESCRIPTION
Rename CompilationUnitSyntax to DocumentSyntax. Introduce SyntaxTree to encapsulate DocumentSyntax, source text, and diagnostics. Add SyntaxDiagnostic infrastructure. Update parser and tests to use new structure.