### PR TITLE
Refactor annotation syntax and support type annotations

### DIFF
--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Annotations/AliasesAnnotationSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Annotations/AliasesAnnotationSyntax.cs
@@ -4,7 +4,7 @@ namespace AvroSourceGenerator.Avdl.Syntax.Annotations;
 
 public sealed record class AliasesAnnotationSyntax(
     SyntaxToken AtSignToken,
-    SyntaxToken AliasesIdentifier,
+    AnnotationNameSyntax AnnotationName,
     SyntaxToken ParenthesisOpenToken,
     JsonValueSyntax JsonValue,
     SyntaxToken ParenthesisCloseToken)
@@ -17,7 +17,7 @@ public sealed record class AliasesAnnotationSyntax(
     public IEnumerable<ISyntaxNode> Children()
     {
         yield return AtSignToken;
-        yield return AliasesIdentifier;
+        yield return AnnotationName;
         yield return ParenthesisOpenToken;
         yield return JsonValue;
         yield return ParenthesisCloseToken;

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Annotations/AnnotationNameSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Annotations/AnnotationNameSyntax.cs
@@ -1,0 +1,10 @@
+﻿namespace AvroSourceGenerator.Avdl.Syntax.Annotations;
+
+public sealed record class AnnotationNameSyntax(SeparatedSyntaxList<SyntaxToken> Identifiers) : ISyntaxNode
+{
+    public SyntaxKind SyntaxKind => SyntaxKind.AnnotationName;
+
+    public string FullName => field ??= string.Join(".", Identifiers.Select(static identifier => identifier.ValueText));
+
+    public IEnumerable<ISyntaxNode> Children() => Identifiers.SyntaxNodes;
+}

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Annotations/CustomAnnotationSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Annotations/CustomAnnotationSyntax.cs
@@ -2,7 +2,7 @@
 
 public sealed record class CustomAnnotationSyntax(
     SyntaxToken AtSignToken,
-    SyntaxToken NameIdentifier,
+    AnnotationNameSyntax AnnotationName,
     SyntaxToken ParenthesisOpenToken,
     JsonValueSyntax JsonValue,
     SyntaxToken ParenthesisCloseToken)
@@ -13,7 +13,7 @@ public sealed record class CustomAnnotationSyntax(
     public IEnumerable<ISyntaxNode> Children()
     {
         yield return AtSignToken;
-        yield return NameIdentifier;
+        yield return AnnotationName;
         yield return ParenthesisOpenToken;
         yield return JsonValue;
         yield return ParenthesisCloseToken;

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Annotations/IAnnotationSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Annotations/IAnnotationSyntax.cs
@@ -2,5 +2,7 @@
 
 public interface IAnnotationSyntax : ISyntaxNode
 {
+    public AnnotationNameSyntax AnnotationName { get; }
+
     public JsonValueSyntax JsonValue { get; }
 }

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Annotations/LogicalTypeAnnotationSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Annotations/LogicalTypeAnnotationSyntax.cs
@@ -2,7 +2,7 @@
 
 public sealed record class LogicalTypeAnnotationSyntax(
     SyntaxToken AtSignToken,
-    SyntaxToken LogicalTypeIdentifier,
+    AnnotationNameSyntax AnnotationName,
     SyntaxToken ParenthesisOpenToken,
     JsonValueSyntax JsonValue,
     SyntaxToken ParenthesisCloseToken)
@@ -15,7 +15,7 @@ public sealed record class LogicalTypeAnnotationSyntax(
     public IEnumerable<ISyntaxNode> Children()
     {
         yield return AtSignToken;
-        yield return LogicalTypeIdentifier;
+        yield return AnnotationName;
         yield return ParenthesisOpenToken;
         yield return JsonValue;
         yield return ParenthesisCloseToken;

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Annotations/NamespaceAnnotationSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Annotations/NamespaceAnnotationSyntax.cs
@@ -2,7 +2,7 @@
 
 public sealed record class NamespaceAnnotationSyntax(
     SyntaxToken AtSignToken,
-    SyntaxToken NamespaceKeyword,
+    AnnotationNameSyntax AnnotationName,
     SyntaxToken ParenthesisOpenToken,
     JsonValueSyntax JsonValue,
     SyntaxToken ParenthesisCloseToken)
@@ -15,7 +15,7 @@ public sealed record class NamespaceAnnotationSyntax(
     public IEnumerable<ISyntaxNode> Children()
     {
         yield return AtSignToken;
-        yield return NamespaceKeyword;
+        yield return AnnotationName;
         yield return ParenthesisOpenToken;
         yield return JsonValue;
         yield return ParenthesisCloseToken;

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Annotations/OrderAnnotationSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Annotations/OrderAnnotationSyntax.cs
@@ -2,7 +2,7 @@
 
 public sealed record class OrderAnnotationSyntax(
     SyntaxToken AtSignToken,
-    SyntaxToken OrderIdentifier,
+    AnnotationNameSyntax AnnotationName,
     SyntaxToken ParenthesisOpenToken,
     JsonValueSyntax JsonValue,
     SyntaxToken ParenthesisCloseToken)
@@ -16,7 +16,7 @@ public sealed record class OrderAnnotationSyntax(
     public IEnumerable<ISyntaxNode> Children()
     {
         yield return AtSignToken;
-        yield return OrderIdentifier;
+        yield return AnnotationName;
         yield return ParenthesisOpenToken;
         yield return JsonValue;
         yield return ParenthesisCloseToken;

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/MessageDeclarationSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/MessageDeclarationSyntax.cs
@@ -1,10 +1,13 @@
-﻿using AvroSourceGenerator.Avdl.Syntax.Types;
+using AvroSourceGenerator.Avdl.Syntax.Annotations;
+using AvroSourceGenerator.Avdl.Syntax.Types;
 
 namespace AvroSourceGenerator.Avdl.Syntax.Declarations;
 
 public sealed record class MessageDeclarationSyntax(
     ITypeSyntax Type,
     SimpleNameSyntax Name,
+    SyntaxList<DocumentationSyntax> Documentation,
+    SyntaxList<IAnnotationSyntax> Annotations,
     SyntaxToken ParenthesisOpenToken,
     SeparatedSyntaxList<ParameterDeclarationSyntax> Parameters,
     SyntaxToken ParenthesisCloseToken,
@@ -19,6 +22,10 @@ public sealed record class MessageDeclarationSyntax(
     {
         yield return Type;
         yield return Name;
+        foreach (var documentation in Documentation)
+            yield return documentation;
+        foreach (var annotation in Annotations)
+            yield return annotation;
         yield return ParenthesisOpenToken;
         foreach (var parameter in Parameters)
         {

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Directives/SchemaDirectiveSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Directives/SchemaDirectiveSyntax.cs
@@ -1,17 +1,21 @@
-﻿namespace AvroSourceGenerator.Avdl.Syntax.Directives;
+using AvroSourceGenerator.Avdl.Syntax.Types;
+
+namespace AvroSourceGenerator.Avdl.Syntax.Directives;
 
 public sealed record class SchemaDirectiveSyntax(
     SyntaxToken SchemaKeyword,
-    SimpleNameSyntax MainSchemaName,
+    ITypeSyntax MainSchemaType,
     SyntaxToken SemicolonToken)
     : IDirectiveSyntax
 {
     public SyntaxKind SyntaxKind => SyntaxKind.SchemaDirective;
 
+    public SimpleNameSyntax? MainSchemaName => (MainSchemaType as NamedTypeSyntax)?.Name as SimpleNameSyntax;
+
     public IEnumerable<ISyntaxNode> Children()
     {
         yield return SchemaKeyword;
-        yield return MainSchemaName;
+        yield return MainSchemaType;
         yield return SemicolonToken;
     }
 }

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Parser.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Parser.cs
@@ -65,9 +65,9 @@ public sealed class Parser(SourceText sourceText)
     private SchemaDirectiveSyntax ParseSchemaDirective()
     {
         var schemaKeyword = _stream.Match(SyntaxKind.SchemaKeyword);
-        var mainSchemaName = ParseSimpleName();
+        var mainSchemaType = ParseType();
         var semicolonToken = _stream.Match(SyntaxKind.SemicolonToken);
-        return new SchemaDirectiveSyntax(schemaKeyword, mainSchemaName, semicolonToken);
+        return new SchemaDirectiveSyntax(schemaKeyword, mainSchemaType, semicolonToken);
     }
 
     private ImportDirectiveSyntax ParseImportDirective()
@@ -131,6 +131,12 @@ public sealed class Parser(SourceText sourceText)
         }
     }
 
+    private void EnqueueDocumentation()
+    {
+        while (_stream.Current.SyntaxKind is SyntaxKind.DocumentationTrivia)
+            _documentation.Add(ParseDocumentation());
+    }
+
     private void ReportAndClearMisplacedMetadata(string target)
     {
         foreach (var documentation in _documentation)
@@ -160,19 +166,29 @@ public sealed class Parser(SourceText sourceText)
     private IAnnotationSyntax ParseAnnotation()
     {
         var atSignToken = _stream.Match(SyntaxKind.AtSignToken);
-        var name = _stream.Current.SyntaxKind is SyntaxKind.NamespaceKeyword ? _stream.Next() : _stream.Match(SyntaxKind.IdentifierToken);
+        var name = ParseAnnotationName();
         var parenthesisOpenToken = _stream.Match(SyntaxKind.ParenthesisOpenToken);
         var jsonValue = ParseJsonValue();
         var parenthesisCloseToken = _stream.Match(SyntaxKind.ParenthesisCloseToken);
-        return name switch
+        return name.FullName switch
         {
-            { SyntaxKind: SyntaxKind.NamespaceKeyword } => new NamespaceAnnotationSyntax(atSignToken, name, parenthesisOpenToken, jsonValue, parenthesisCloseToken),
-            { ValueText: "aliases" } => new AliasesAnnotationSyntax(atSignToken, name, parenthesisOpenToken, jsonValue, parenthesisCloseToken),
-            { ValueText: "order" } => new OrderAnnotationSyntax(atSignToken, name, parenthesisOpenToken, jsonValue, parenthesisCloseToken),
-            { ValueText: "logicalType" } => new LogicalTypeAnnotationSyntax(atSignToken, name, parenthesisOpenToken, jsonValue, parenthesisCloseToken),
+            "namespace" => new NamespaceAnnotationSyntax(atSignToken, name, parenthesisOpenToken, jsonValue, parenthesisCloseToken),
+            "aliases" => new AliasesAnnotationSyntax(atSignToken, name, parenthesisOpenToken, jsonValue, parenthesisCloseToken),
+            "order" => new OrderAnnotationSyntax(atSignToken, name, parenthesisOpenToken, jsonValue, parenthesisCloseToken),
+            "logicalType" => new LogicalTypeAnnotationSyntax(atSignToken, name, parenthesisOpenToken, jsonValue, parenthesisCloseToken),
 
             _ => new CustomAnnotationSyntax(atSignToken, name, parenthesisOpenToken, jsonValue, parenthesisCloseToken),
         };
+    }
+
+    private AnnotationNameSyntax ParseAnnotationName()
+    {
+        var separatedIdentifiers = ParseSeparatedList(
+            parseNode: () => _stream.Current.SyntaxKind is SyntaxKind.NamespaceKeyword ? _stream.Next() : _stream.Match(SyntaxKind.IdentifierToken),
+            separator: SyntaxKind.DotToken,
+            terminators: SyntaxKind.ParenthesisOpenToken);
+
+        return new AnnotationNameSyntax(separatedIdentifiers);
     }
 
     private JsonValueSyntax ParseJsonValue()
@@ -239,7 +255,7 @@ public sealed class Parser(SourceText sourceText)
 
     private FieldDeclarationSyntax ParseFieldDeclaration()
     {
-        EnqueueMetadata();
+        EnqueueDocumentation();
         var type = ParseType();
         EnqueueMetadata();
         var name = ParseSimpleName();
@@ -294,7 +310,6 @@ public sealed class Parser(SourceText sourceText)
                     types.Add(ParseErrorDeclaration());
                     break;
                 default:
-                    ReportAndClearMisplacedMetadata("message declaration");
                     messages.Add(ParseMessageDeclaration());
                     break;
             }
@@ -318,6 +333,7 @@ public sealed class Parser(SourceText sourceText)
     {
         var type = ParseType();
         var name = ParseSimpleName();
+        var (documentation, annotations) = DequeueMetadata();
         var parenthesisOpenToken = _stream.Match(SyntaxKind.ParenthesisOpenToken);
         var parameters = ParseSeparatedList(ParseParameterDeclaration, SyntaxKind.CommaToken, SyntaxKind.ParenthesisCloseToken);
         var parenthesisCloseToken = _stream.Match(SyntaxKind.ParenthesisCloseToken);
@@ -327,6 +343,8 @@ public sealed class Parser(SourceText sourceText)
         return new MessageDeclarationSyntax(
             type,
             name,
+            documentation,
+            annotations,
             parenthesisOpenToken,
             parameters,
             parenthesisCloseToken,
@@ -380,6 +398,15 @@ public sealed class Parser(SourceText sourceText)
 
     private ITypeSyntax ParseType()
     {
+        SyntaxList<IAnnotationSyntax> annotations = [];
+        if (_stream.Current.SyntaxKind is SyntaxKind.AtSignToken)
+        {
+            var builder = ImmutableArray.CreateBuilder<IAnnotationSyntax>();
+            while (_stream.Current.SyntaxKind is SyntaxKind.AtSignToken)
+                builder.Add(ParseAnnotation());
+            annotations = new SyntaxList<IAnnotationSyntax>(builder.ToImmutable());
+        }
+
         ITypeSyntax type = _stream.Current.SyntaxKind switch
         {
             SyntaxKind.VoidKeyword
@@ -409,6 +436,11 @@ public sealed class Parser(SourceText sourceText)
         if (_stream.Current.SyntaxKind is SyntaxKind.QuestionMarkToken)
         {
             type = new OptionalTypeSyntax(type, _stream.Next());
+        }
+
+        if (annotations.Count > 0)
+        {
+            type = new AnnotatedTypeSyntax(annotations, type);
         }
 
         return type;
@@ -497,15 +529,7 @@ public sealed class Parser(SourceText sourceText)
         };
 
     private static string GetAnnotationName(IAnnotationSyntax annotation) =>
-        annotation switch
-        {
-            NamespaceAnnotationSyntax => "namespace",
-            AliasesAnnotationSyntax aliasesAnnotation => aliasesAnnotation.AliasesIdentifier.ValueText,
-            OrderAnnotationSyntax orderAnnotation => orderAnnotation.OrderIdentifier.ValueText,
-            LogicalTypeAnnotationSyntax logicalTypeAnnotation => logicalTypeAnnotation.LogicalTypeIdentifier.ValueText,
-            CustomAnnotationSyntax customAnnotation => customAnnotation.NameIdentifier.ValueText,
-            _ => "unknown",
-        };
+        annotation.AnnotationName.FullName;
 }
 
 file static class SpanExtensions

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Parser.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Parser.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using AvroSourceGenerator.Avdl.Diagnostics;
 using AvroSourceGenerator.Avdl.Syntax.Annotations;
 using AvroSourceGenerator.Avdl.Syntax.Declarations;
@@ -65,9 +65,9 @@ public sealed class Parser(SourceText sourceText)
     private SchemaDirectiveSyntax ParseSchemaDirective()
     {
         var schemaKeyword = _stream.Match(SyntaxKind.SchemaKeyword);
-        var mainSchemaName = ParseSimpleName();
+        var mainSchemaType = ParseType();
         var semicolonToken = _stream.Match(SyntaxKind.SemicolonToken);
-        return new SchemaDirectiveSyntax(schemaKeyword, mainSchemaName, semicolonToken);
+        return new SchemaDirectiveSyntax(schemaKeyword, mainSchemaType, semicolonToken);
     }
 
     private ImportDirectiveSyntax ParseImportDirective()
@@ -131,6 +131,12 @@ public sealed class Parser(SourceText sourceText)
         }
     }
 
+    private void EnqueueDocumentation()
+    {
+        while (_stream.Current.SyntaxKind is SyntaxKind.DocumentationTrivia)
+            _documentation.Add(ParseDocumentation());
+    }
+
     private void ReportAndClearMisplacedMetadata(string target)
     {
         foreach (var documentation in _documentation)
@@ -160,19 +166,29 @@ public sealed class Parser(SourceText sourceText)
     private IAnnotationSyntax ParseAnnotation()
     {
         var atSignToken = _stream.Match(SyntaxKind.AtSignToken);
-        var name = _stream.Current.SyntaxKind is SyntaxKind.NamespaceKeyword ? _stream.Next() : _stream.Match(SyntaxKind.IdentifierToken);
+        var name = ParseAnnotationName();
         var parenthesisOpenToken = _stream.Match(SyntaxKind.ParenthesisOpenToken);
         var jsonValue = ParseJsonValue();
         var parenthesisCloseToken = _stream.Match(SyntaxKind.ParenthesisCloseToken);
-        return name switch
+        return name.FullName switch
         {
-            { SyntaxKind: SyntaxKind.NamespaceKeyword } => new NamespaceAnnotationSyntax(atSignToken, name, parenthesisOpenToken, jsonValue, parenthesisCloseToken),
-            { ValueText: "aliases" } => new AliasesAnnotationSyntax(atSignToken, name, parenthesisOpenToken, jsonValue, parenthesisCloseToken),
-            { ValueText: "order" } => new OrderAnnotationSyntax(atSignToken, name, parenthesisOpenToken, jsonValue, parenthesisCloseToken),
-            { ValueText: "logicalType" } => new LogicalTypeAnnotationSyntax(atSignToken, name, parenthesisOpenToken, jsonValue, parenthesisCloseToken),
+            "namespace" => new NamespaceAnnotationSyntax(atSignToken, name, parenthesisOpenToken, jsonValue, parenthesisCloseToken),
+            "aliases" => new AliasesAnnotationSyntax(atSignToken, name, parenthesisOpenToken, jsonValue, parenthesisCloseToken),
+            "order" => new OrderAnnotationSyntax(atSignToken, name, parenthesisOpenToken, jsonValue, parenthesisCloseToken),
+            "logicalType" => new LogicalTypeAnnotationSyntax(atSignToken, name, parenthesisOpenToken, jsonValue, parenthesisCloseToken),
 
             _ => new CustomAnnotationSyntax(atSignToken, name, parenthesisOpenToken, jsonValue, parenthesisCloseToken),
         };
+    }
+
+    private AnnotationNameSyntax ParseAnnotationName()
+    {
+        var separatedIdentifiers = ParseSeparatedList(
+            parseNode: () => _stream.Current.SyntaxKind is SyntaxKind.NamespaceKeyword ? _stream.Next() : _stream.Match(SyntaxKind.IdentifierToken),
+            separator: SyntaxKind.DotToken,
+            terminators: SyntaxKind.ParenthesisOpenToken);
+
+        return new AnnotationNameSyntax(separatedIdentifiers);
     }
 
     private JsonValueSyntax ParseJsonValue()
@@ -239,7 +255,7 @@ public sealed class Parser(SourceText sourceText)
 
     private FieldDeclarationSyntax ParseFieldDeclaration()
     {
-        EnqueueMetadata();
+        EnqueueDocumentation();
         var type = ParseType();
         EnqueueMetadata();
         var name = ParseSimpleName();
@@ -294,7 +310,6 @@ public sealed class Parser(SourceText sourceText)
                     types.Add(ParseErrorDeclaration());
                     break;
                 default:
-                    ReportAndClearMisplacedMetadata("message declaration");
                     messages.Add(ParseMessageDeclaration());
                     break;
             }
@@ -318,6 +333,7 @@ public sealed class Parser(SourceText sourceText)
     {
         var type = ParseType();
         var name = ParseSimpleName();
+        var (documentation, annotations) = DequeueMetadata();
         var parenthesisOpenToken = _stream.Match(SyntaxKind.ParenthesisOpenToken);
         var parameters = ParseSeparatedList(ParseParameterDeclaration, SyntaxKind.CommaToken, SyntaxKind.ParenthesisCloseToken);
         var parenthesisCloseToken = _stream.Match(SyntaxKind.ParenthesisCloseToken);
@@ -327,6 +343,8 @@ public sealed class Parser(SourceText sourceText)
         return new MessageDeclarationSyntax(
             type,
             name,
+            documentation,
+            annotations,
             parenthesisOpenToken,
             parameters,
             parenthesisCloseToken,
@@ -380,6 +398,15 @@ public sealed class Parser(SourceText sourceText)
 
     private ITypeSyntax ParseType()
     {
+        SyntaxList<IAnnotationSyntax> annotations = [];
+        if (_stream.Current.SyntaxKind is SyntaxKind.AtSignToken)
+        {
+            var builder = ImmutableArray.CreateBuilder<IAnnotationSyntax>();
+            while (_stream.Current.SyntaxKind is SyntaxKind.AtSignToken)
+                builder.Add(ParseAnnotation());
+            annotations = new SyntaxList<IAnnotationSyntax>(builder.ToImmutable());
+        }
+
         ITypeSyntax type = _stream.Current.SyntaxKind switch
         {
             SyntaxKind.VoidKeyword
@@ -409,6 +436,11 @@ public sealed class Parser(SourceText sourceText)
         if (_stream.Current.SyntaxKind is SyntaxKind.QuestionMarkToken)
         {
             type = new OptionalTypeSyntax(type, _stream.Next());
+        }
+
+        if (annotations.Count > 0)
+        {
+            type = new AnnotatedTypeSyntax(annotations, type);
         }
 
         return type;
@@ -497,15 +529,7 @@ public sealed class Parser(SourceText sourceText)
         };
 
     private static string GetAnnotationName(IAnnotationSyntax annotation) =>
-        annotation switch
-        {
-            NamespaceAnnotationSyntax => "namespace",
-            AliasesAnnotationSyntax aliasesAnnotation => aliasesAnnotation.AliasesIdentifier.ValueText,
-            OrderAnnotationSyntax orderAnnotation => orderAnnotation.OrderIdentifier.ValueText,
-            LogicalTypeAnnotationSyntax logicalTypeAnnotation => logicalTypeAnnotation.LogicalTypeIdentifier.ValueText,
-            CustomAnnotationSyntax customAnnotation => customAnnotation.NameIdentifier.ValueText,
-            _ => "unknown",
-        };
+        annotation.AnnotationName.FullName;
 }
 
 file static class SpanExtensions

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Scanner.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Scanner.cs
@@ -352,7 +352,7 @@ public sealed class Scanner(SourceText sourceText)
             return CreateInvalidToken(sourceSpan, SyntaxDiagnostic.InvalidCharacter(sourceSpan));
         }
 
-        var length = GetIdentifierLength(identifierSpan, _previousSyntaxToken?.SyntaxKind is SyntaxKind.AtSignToken);
+        var length = GetIdentifierLength(identifierSpan, _previousSyntaxToken?.SyntaxKind is SyntaxKind.AtSignToken or SyntaxKind.DotToken);
 
         if (isVerbatim)
         {

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/SyntaxFacts.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/SyntaxFacts.cs
@@ -95,6 +95,7 @@ public static class SyntaxFacts
             SyntaxKind.MapType => null,
             SyntaxKind.UnionType => null,
             SyntaxKind.OptionalType => null,
+            SyntaxKind.AnnotatedType => null,
             SyntaxKind.NamedType => null,
             SyntaxKind.LogicalType => null,
 
@@ -104,6 +105,7 @@ public static class SyntaxFacts
 
             SyntaxKind.Documentation => null,
 
+            SyntaxKind.AnnotationName => null,
             SyntaxKind.NamespaceAnnotation => null,
             SyntaxKind.AliasesAnnotation => null,
             SyntaxKind.OrderAnnotation => null,

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/SyntaxKind.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/SyntaxKind.cs
@@ -97,6 +97,7 @@ public enum SyntaxKind
     MapType,
     UnionType,
     OptionalType,
+    AnnotatedType,
     NamedType,
     LogicalType,
 
@@ -106,6 +107,7 @@ public enum SyntaxKind
 
     Documentation,
 
+    AnnotationName,
     NamespaceAnnotation,
     AliasesAnnotation,
     OrderAnnotation,

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Types/AnnotatedTypeSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Types/AnnotatedTypeSyntax.cs
@@ -1,0 +1,15 @@
+using AvroSourceGenerator.Avdl.Syntax.Annotations;
+
+namespace AvroSourceGenerator.Avdl.Syntax.Types;
+
+public sealed record class AnnotatedTypeSyntax(SyntaxList<IAnnotationSyntax> Annotations, ITypeSyntax Type) : ITypeSyntax
+{
+    public SyntaxKind SyntaxKind => SyntaxKind.AnnotatedType;
+
+    public IEnumerable<ISyntaxNode> Children()
+    {
+        foreach (var annotation in Annotations)
+            yield return annotation;
+        yield return Type;
+    }
+}

--- a/tests/AvroSourceGenerator.Tests/Avdl/ParserTests.cs
+++ b/tests/AvroSourceGenerator.Tests/Avdl/ParserTests.cs
@@ -24,7 +24,7 @@ public sealed class ParserTests
 
         Assert.Equal(5, unit.Directives.Count);
         Assert.IsType<QualifiedNameSyntax>(Assert.IsType<NamespaceDirectiveSyntax>(unit.Directives[0]).NamespaceName);
-        Assert.Equal("Main", Assert.IsType<SchemaDirectiveSyntax>(unit.Directives[1]).MainSchemaName.Identifier.SourceSpan.ToString());
+        Assert.Equal("Main", Assert.IsType<SchemaDirectiveSyntax>(unit.Directives[1]).MainSchemaName!.Identifier.SourceSpan.ToString());
 
         var idlImport = Assert.IsType<ImportDirectiveSyntax>(unit.Directives[2]);
         Assert.Equal(SyntaxKind.IdlKeyword, idlImport.ImportTypeKeyword.SyntaxKind);
@@ -41,6 +41,19 @@ public sealed class ParserTests
         var protocol = Assert.IsType<ProtocolDeclarationSyntax>(Assert.Single(unit.Declarations));
         Assert.Equal("P", protocol.Name.Identifier.SourceSpan.ToString());
         Assert.Empty(protocol.Imports);
+    }
+
+    [Theory]
+    [InlineData("schema int;", SyntaxKind.IntType)]
+    [InlineData("schema array<string>;", SyntaxKind.ArrayType)]
+    [InlineData("schema union { null, string };", SyntaxKind.UnionType)]
+    [InlineData("schema Message;", SyntaxKind.NamedType)]
+    public void Parse_SchemaDirective_ReturnsMainSchemaType(string text, SyntaxKind expectedTypeKind)
+    {
+        var unit = Parse(text);
+
+        var schema = Assert.IsType<SchemaDirectiveSyntax>(Assert.Single(unit.Directives));
+        Assert.Equal(expectedTypeKind, schema.MainSchemaType.SyntaxKind);
     }
 
     [Fact]
@@ -190,7 +203,8 @@ public sealed class ParserTests
         Assert.IsType<MapTypeSyntax>(request.Fields[1].Type);
         Assert.IsType<UnionTypeSyntax>(request.Fields[2].Type);
         Assert.IsType<OptionalTypeSyntax>(request.Fields[3].Type);
-        Assert.Single(request.Fields[4].Annotations);
+        Assert.Empty(request.Fields[4].Annotations);
+        Assert.Single(Assert.IsType<AnnotatedTypeSyntax>(request.Fields[4].Type).Annotations);
 
         var ping = protocol.Messages[0];
         Assert.Equal(SyntaxKind.VoidType, ping.Type.SyntaxKind);
@@ -238,7 +252,7 @@ public sealed class ParserTests
         var record = Assert.IsType<RecordDeclarationSyntax>(Assert.Single(unit.Declarations));
         var annotation = Assert.IsType<CustomAnnotationSyntax>(Assert.Single(record.Annotations));
 
-        Assert.Equal("java-class", annotation.NameIdentifier.ValueText);
+        Assert.Equal("java-class", annotation.AnnotationName.FullName);
         Assert.Equal("com.example.User", annotation.JsonValue.JsonNode!.GetValue<string>());
     }
 
@@ -256,14 +270,75 @@ public sealed class ParserTests
         var record = Assert.IsType<RecordDeclarationSyntax>(Assert.Single(unit.Declarations));
 
         var id = record.Fields[0];
-        var uuid = Assert.IsType<LogicalTypeAnnotationSyntax>(Assert.Single(id.Annotations));
-        Assert.Equal("logicalType", uuid.LogicalTypeIdentifier.ValueText);
+        Assert.Empty(id.Annotations);
+        var idType = Assert.IsType<AnnotatedTypeSyntax>(id.Type);
+        var uuid = Assert.IsType<LogicalTypeAnnotationSyntax>(Assert.Single(idType.Annotations));
+        Assert.Equal("logicalType", uuid.AnnotationName.FullName);
         Assert.Equal("uuid", uuid.LogicalTypeName);
         Assert.Equal("uuid", uuid.JsonValue.JsonNode!.GetValue<string>());
+        Assert.Equal(SyntaxKind.StringType, idType.Type.SyntaxKind);
 
         var createdAt = record.Fields[1];
-        var timestampMillis = Assert.IsType<LogicalTypeAnnotationSyntax>(Assert.Single(createdAt.Annotations));
+        Assert.Empty(createdAt.Annotations);
+        var createdAtType = Assert.IsType<AnnotatedTypeSyntax>(createdAt.Type);
+        var timestampMillis = Assert.IsType<LogicalTypeAnnotationSyntax>(Assert.Single(createdAtType.Annotations));
         Assert.Equal("timestamp-millis", timestampMillis.LogicalTypeName);
+        Assert.Equal(SyntaxKind.LongType, createdAtType.Type.SyntaxKind);
+    }
+
+    [Fact]
+    public void Parse_MessageMetadata_ReturnsDocumentationAndAnnotationsOnMessage()
+    {
+        var tree = ParseTree(
+            """
+            protocol P {
+                /** Ping doc */
+                @timeout-ms(1000)
+                void ping();
+            }
+            """);
+
+        Assert.Empty(tree.Diagnostics);
+        var protocol = Assert.IsType<ProtocolDeclarationSyntax>(Assert.Single(tree.Document.Declarations));
+        var message = Assert.Single(protocol.Messages);
+        Assert.Equal(" Ping doc ", Assert.Single(message.Documentation).DocumentationTrivia.SourceSpan.ToString());
+        var annotation = Assert.IsType<CustomAnnotationSyntax>(Assert.Single(message.Annotations));
+        Assert.Equal("timeout-ms", annotation.AnnotationName.FullName);
+    }
+
+    [Fact]
+    public void Parse_CustomAnnotation_AllowsDottedAndDashedName()
+    {
+        var unit = Parse(
+            """
+            @foo.bar-baz(true)
+            record User {}
+            """);
+
+        var record = Assert.IsType<RecordDeclarationSyntax>(Assert.Single(unit.Declarations));
+        var annotation = Assert.IsType<CustomAnnotationSyntax>(Assert.Single(record.Annotations));
+
+        Assert.Equal("foo.bar-baz", annotation.AnnotationName.FullName);
+        Assert.True(annotation.JsonValue.JsonNode!.GetValue<bool>());
+    }
+
+    [Fact]
+    public void Parse_NestedTypeAnnotation_ReturnsAnnotatedTypeSyntax()
+    {
+        var unit = Parse(
+            """
+            record Weights {
+                array<@java-class("java.math.BigDecimal") string> weights;
+            }
+            """);
+
+        var record = Assert.IsType<RecordDeclarationSyntax>(Assert.Single(unit.Declarations));
+        var array = Assert.IsType<ArrayTypeSyntax>(Assert.Single(record.Fields).Type);
+        var itemType = Assert.IsType<AnnotatedTypeSyntax>(array.ItemType);
+        var annotation = Assert.IsType<CustomAnnotationSyntax>(Assert.Single(itemType.Annotations));
+
+        Assert.Equal("java-class", annotation.AnnotationName.FullName);
+        Assert.Equal(SyntaxKind.StringType, itemType.Type.SyntaxKind);
     }
 
     [Fact]


### PR DESCRIPTION
- Introduce AnnotationNameSyntax for dotted/dashed annotation names
- Update annotation records and IAnnotationSyntax to use AnnotationNameSyntax
- Add AnnotatedTypeSyntax for types with annotations
- Allow annotations directly on types in the parser
- Change SchemaDirectiveSyntax to accept ITypeSyntax as main type
- Support message-level documentation and annotations
- Enhance identifier scanning for annotation names
- Update and expand tests for new annotation features