### PR TITLE
Use Apache codegen names for Schema and Protocol static fields

### DIFF
--- a/src/AvroSourceGenerator.Templating/Templates/error.sbncs
+++ b/src/AvroSourceGenerator.Templating/Templates/error.sbncs
@@ -7,8 +7,8 @@
 {{ if TargetProfile == 'Apache' }}
 partial {{ Error }} {{ $.schema.CSharpName.Name }} : global::Avro.Specific.SpecificException
 {
-    public override global::Avro.Schema Schema { get => {{ $.schema.CSharpName.Name }}.s_schema; }
-    private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+    public override global::Avro.Schema Schema { get => {{ $.schema.CSharpName.Name }}._SCHEMA; }
+    public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
     {{ SchemaJson }});
 
     {{ include 'getput' schema: $.schema override: true ~}}

--- a/src/AvroSourceGenerator.Templating/Templates/fixed.sbncs
+++ b/src/AvroSourceGenerator.Templating/Templates/fixed.sbncs
@@ -7,7 +7,7 @@ partial {{ Fixed }} {{ $.schema.CSharpName.Name }} : global::Avro.Specific.Speci
 {
     public {{ $.schema.CSharpName.Name }}() : base({{ $.schema.Size }}) { }
 
-    public override global::Avro.Schema Schema { get => {{ $.schema.CSharpName.Name }}.s_schema; }
-    private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+    public override global::Avro.Schema Schema { get => {{ $.schema.CSharpName.Name }}._SCHEMA; }
+    public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
     {{ SchemaJson }});
 }

--- a/src/AvroSourceGenerator.Templating/Templates/protocol.sbncs
+++ b/src/AvroSourceGenerator.Templating/Templates/protocol.sbncs
@@ -17,8 +17,8 @@
 {{ if TargetProfile == 'Apache' }}
 partial class {{ $.schema.CSharpName.Name }} : global::Avro.Specific.ISpecificProtocol
 {
-    public global::Avro.Protocol Protocol { get => {{ $.schema.CSharpName.Name }}.s_protocol; }
-    private static readonly global::Avro.Protocol s_protocol = global::Avro.Protocol.Parse(
+    public global::Avro.Protocol Protocol { get => {{ $.schema.CSharpName.Name }}.protocol; }
+    private static readonly global::Avro.Protocol protocol = global::Avro.Protocol.Parse(
     {{ SchemaJson }});
 
     public void Request(global::Avro.Specific.ICallbackRequestor requestor, string messageName, object[] args, object callback)

--- a/src/AvroSourceGenerator.Templating/Templates/record.sbncs
+++ b/src/AvroSourceGenerator.Templating/Templates/record.sbncs
@@ -7,8 +7,8 @@
 {{ if TargetProfile == 'Apache' }}
 partial {{ Record }} {{ $.schema.CSharpName.Name }} : global::Avro.Specific.ISpecificRecord
 {
-    global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => {{ $.schema.CSharpName.Name }}.s_schema; }
-    private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+    global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => {{ $.schema.CSharpName.Name }}._SCHEMA; }
+    public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
     {{ SchemaJson }});
 
     {{ include 'getput' schema: $.schema override: false ~}}

--- a/src/AvroSourceGenerator.Templating/Templates/schema.sbncs
+++ b/src/AvroSourceGenerator.Templating/Templates/schema.sbncs
@@ -37,4 +37,4 @@ namespace {{ Schema.CSharpName.Namespace }}
 {{~ if UseNullableReferenceTypes && Schema.RequiresNullability ~}}
 #nullable restore
 {{~ end ~}}
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.IntegrationTests.Apache/AvroProtocolTests.cs
+++ b/tests/AvroSourceGenerator.IntegrationTests.Apache/AvroProtocolTests.cs
@@ -23,7 +23,7 @@ public sealed class AvroProtocolTests
     private static Avro.Protocol GetGeneratedTypeProtocol(string typeName)
     {
         var type = Type.GetType($"AvroSourceGenerator.IntegrationTests.Schemas.{typeName}", throwOnError: true)!;
-        var field = type.GetField("s_protocol", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)!;
+        var field = type.GetField("protocol", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)!;
         return (Avro.Protocol)field.GetValue(null)!;
     }
 }

--- a/tests/AvroSourceGenerator.IntegrationTests.Apache/AvroSchemaTests.cs
+++ b/tests/AvroSourceGenerator.IntegrationTests.Apache/AvroSchemaTests.cs
@@ -25,7 +25,7 @@ public sealed class AvroSchemaTests
     private static Avro.Schema GetGeneratedTypeSchema(string typeName)
     {
         var type = Type.GetType($"AvroSourceGenerator.IntegrationTests.Schemas.{typeName}", throwOnError: true)!;
-        var field = type.GetField("s_schema", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)!;
+        var field = type.GetField("_SCHEMA", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)!;
         return (Avro.Schema)field.GetValue(null)!;
     }
 }

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/Bugs/NestedTypeTests.Verify.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/Bugs/NestedTypeTests.Verify.verified.txt
@@ -9,8 +9,8 @@
     
     partial record SomeSchema : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => SomeSchema.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => SomeSchema._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -51,4 +51,4 @@
         }
     }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=error.verified.txt
@@ -10,8 +10,8 @@ namespace SchemaNamespace
     
     partial class Error : global::Avro.Specific.SpecificException
     {
-        public override global::Avro.Schema Schema { get => Error.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "error",
@@ -40,4 +40,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=fixed.verified.txt
@@ -12,8 +12,8 @@ namespace SchemaNamespace
     {
         public Fixed() : base(16) { }
     
-        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",
@@ -24,4 +24,4 @@ namespace SchemaNamespace
         """);
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=protocol.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=protocol.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
     partial class RpcProtocol : global::Avro.Specific.ISpecificProtocol
     {
-        public global::Avro.Protocol Protocol { get => RpcProtocol.s_protocol; }
-        private static readonly global::Avro.Protocol s_protocol = global::Avro.Protocol.Parse(
+        public global::Avro.Protocol Protocol { get => RpcProtocol.protocol; }
+        private static readonly global::Avro.Protocol protocol = global::Avro.Protocol.Parse(
         """
         {
           "protocol": "RpcProtocol",
@@ -32,4 +32,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=record.verified.txt
@@ -10,8 +10,8 @@ namespace SchemaNamespace
     
     partial record Record : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -40,4 +40,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=error.verified.txt
@@ -10,8 +10,8 @@ namespace SchemaNamespace
     
     partial class Error : global::Avro.Specific.SpecificException
     {
-        public override global::Avro.Schema Schema { get => Error.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "error",
@@ -40,4 +40,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=fixed.verified.txt
@@ -12,8 +12,8 @@ namespace SchemaNamespace
     {
         public Fixed() : base(16) { }
     
-        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",
@@ -24,4 +24,4 @@ namespace SchemaNamespace
         """);
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=protocol.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=protocol.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
     partial class RpcProtocol : global::Avro.Specific.ISpecificProtocol
     {
-        public global::Avro.Protocol Protocol { get => RpcProtocol.s_protocol; }
-        private static readonly global::Avro.Protocol s_protocol = global::Avro.Protocol.Parse(
+        public global::Avro.Protocol Protocol { get => RpcProtocol.protocol; }
+        private static readonly global::Avro.Protocol protocol = global::Avro.Protocol.Parse(
         """
         {
           "protocol": "RpcProtocol",
@@ -32,4 +32,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=record.verified.txt
@@ -10,8 +10,8 @@ namespace SchemaNamespace
     
     partial record Record : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -40,4 +40,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=error.verified.txt
@@ -10,8 +10,8 @@ namespace SchemaNamespace
     
     partial class Error : global::Avro.Specific.SpecificException
     {
-        public override global::Avro.Schema Schema { get => Error.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "error",
@@ -40,4 +40,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=fixed.verified.txt
@@ -12,8 +12,8 @@ namespace SchemaNamespace
     {
         public Fixed() : base(16) { }
     
-        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",
@@ -24,4 +24,4 @@ namespace SchemaNamespace
         """);
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=protocol.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=protocol.verified.txt
@@ -9,8 +9,8 @@ namespace SchemaNamespace
     
     partial class RpcProtocol : global::Avro.Specific.ISpecificProtocol
     {
-        public global::Avro.Protocol Protocol { get => RpcProtocol.s_protocol; }
-        private static readonly global::Avro.Protocol s_protocol = global::Avro.Protocol.Parse(
+        public global::Avro.Protocol Protocol { get => RpcProtocol.protocol; }
+        private static readonly global::Avro.Protocol protocol = global::Avro.Protocol.Parse(
         """
         {
           "protocol": "RpcProtocol",
@@ -32,4 +32,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=record.verified.txt
@@ -10,8 +10,8 @@ namespace SchemaNamespace
     
     partial record Record : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -40,4 +40,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=error.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial class Error : global::Avro.Specific.SpecificException
     {
-        public override global::Avro.Schema Schema { get => Error.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         "{\"type\":\"error\",\"name\":\"Error\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}],\"messages\":{\"hello\":{\"doc\":\"Say hello.\",\"request\":[{\"type\":\"Greeting\",\"name\":\"greeting\"}],\"response\":\"Greeting\",\"errors\":[\"Curse\"]}},\"types\":[{\"name\":\"Greeting\",\"type\":\"record\",\"fields\":[{\"type\":\"string\",\"name\":\"message\"}]},{\"name\":\"Curse\",\"type\":\"error\",\"fields\":[{\"type\":\"string\",\"name\":\"message\"}]}]}");
     
         public override object? Get(int fieldPos)
@@ -50,4 +50,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=fixed.verified.txt
@@ -12,9 +12,9 @@ namespace SchemaNamespace
     {
         public Fixed() : base(16) { }
     
-        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         "{\"type\":\"fixed\",\"name\":\"Fixed\",\"namespace\":\"SchemaNamespace\",\"size\":16,\"messages\":{\"hello\":{\"doc\":\"Say hello.\",\"request\":[{\"type\":\"Greeting\",\"name\":\"greeting\"}],\"response\":\"Greeting\",\"errors\":[\"Curse\"]}},\"types\":[{\"name\":\"Greeting\",\"type\":\"record\",\"fields\":[{\"type\":\"string\",\"name\":\"message\"}]},{\"name\":\"Curse\",\"type\":\"error\",\"fields\":[{\"type\":\"string\",\"name\":\"message\"}]}]}");
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=protocol#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=protocol#00.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial record Greeting : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Greeting.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Greeting._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Greeting\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"message\",\"type\":\"string\"}]}");
     
         object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
@@ -50,4 +50,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=protocol#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=protocol#01.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial class Curse : global::Avro.Specific.SpecificException
     {
-        public override global::Avro.Schema Schema { get => Curse.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Curse._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         "{\"type\":\"error\",\"name\":\"Curse\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"message\",\"type\":\"string\"}]}");
     
         public override object? Get(int fieldPos)
@@ -50,4 +50,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=protocol#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=protocol#02.verified.txt
@@ -13,8 +13,8 @@ namespace SchemaNamespace
     
     partial class RpcProtocol : global::Avro.Specific.ISpecificProtocol
     {
-        public global::Avro.Protocol Protocol { get => RpcProtocol.s_protocol; }
-        private static readonly global::Avro.Protocol s_protocol = global::Avro.Protocol.Parse(
+        public global::Avro.Protocol Protocol { get => RpcProtocol.protocol; }
+        private static readonly global::Avro.Protocol protocol = global::Avro.Protocol.Parse(
         "{\"protocol\":\"RpcProtocol\",\"namespace\":\"SchemaNamespace\",\"types\":[{\"type\":\"record\",\"name\":\"Greeting\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"message\",\"type\":\"string\"}]},{\"type\":\"error\",\"name\":\"Curse\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"message\",\"type\":\"string\"}]}],\"messages\":{\"hello\":{\"doc\":\"Say hello.\",\"request\":[{\"name\":\"greeting\",\"type\":\"Greeting\"}],\"response\":\"Greeting\",\"errors\":[\"Curse\"]}},\"fields\":[{\"type\":\"string\",\"name\":\"Field\"}]}");
     
         public void Request(global::Avro.Specific.ICallbackRequestor requestor, string messageName, object[] args, object callback)
@@ -40,4 +40,4 @@ namespace SchemaNamespace
     
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=record.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial record Record : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}],\"messages\":{\"hello\":{\"doc\":\"Say hello.\",\"request\":[{\"type\":\"Greeting\",\"name\":\"greeting\"}],\"response\":\"Greeting\",\"errors\":[\"Curse\"]}},\"types\":[{\"name\":\"Greeting\",\"type\":\"record\",\"fields\":[{\"type\":\"string\",\"name\":\"message\"}]},{\"name\":\"Curse\",\"type\":\"error\",\"fields\":[{\"type\":\"string\",\"name\":\"message\"}]}]}");
     
         object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
@@ -50,4 +50,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=error.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial class Error : global::Avro.Specific.SpecificException
     {
-        public override global::Avro.Schema Schema { get => Error.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "error",
@@ -99,4 +99,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=fixed.verified.txt
@@ -12,8 +12,8 @@ namespace SchemaNamespace
     {
         public Fixed() : base(16) { }
     
-        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",
@@ -61,4 +61,4 @@ namespace SchemaNamespace
         """);
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=protocol#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=protocol#00.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial record Greeting : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Greeting.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Greeting._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -62,4 +62,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=protocol#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=protocol#01.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial class Curse : global::Avro.Specific.SpecificException
     {
-        public override global::Avro.Schema Schema { get => Curse.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Curse._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "error",
@@ -62,4 +62,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=protocol#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=protocol#02.verified.txt
@@ -13,8 +13,8 @@ namespace SchemaNamespace
     
     partial class RpcProtocol : global::Avro.Specific.ISpecificProtocol
     {
-        public global::Avro.Protocol Protocol { get => RpcProtocol.s_protocol; }
-        private static readonly global::Avro.Protocol s_protocol = global::Avro.Protocol.Parse(
+        public global::Avro.Protocol Protocol { get => RpcProtocol.protocol; }
+        private static readonly global::Avro.Protocol protocol = global::Avro.Protocol.Parse(
         """
         {
           "protocol": "RpcProtocol",
@@ -90,4 +90,4 @@ namespace SchemaNamespace
     
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=record.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial record Record : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -99,4 +99,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=error.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial class Error : global::Avro.Specific.SpecificException
     {
-        public override global::Avro.Schema Schema { get => Error.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "error",
@@ -88,4 +88,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=fixed.verified.txt
@@ -12,8 +12,8 @@ namespace SchemaNamespace
     {
         public Fixed() : base(16) { }
     
-        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",
@@ -61,4 +61,4 @@ namespace SchemaNamespace
         """);
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=protocol#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=protocol#00.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial record Greeting : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Greeting.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Greeting._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -51,4 +51,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=protocol#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=protocol#01.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial class Curse : global::Avro.Specific.SpecificException
     {
-        public override global::Avro.Schema Schema { get => Curse.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Curse._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "error",
@@ -51,4 +51,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=protocol#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=protocol#02.verified.txt
@@ -13,8 +13,8 @@ namespace SchemaNamespace
     
     partial class RpcProtocol : global::Avro.Specific.ISpecificProtocol
     {
-        public global::Avro.Protocol Protocol { get => RpcProtocol.s_protocol; }
-        private static readonly global::Avro.Protocol s_protocol = global::Avro.Protocol.Parse(
+        public global::Avro.Protocol Protocol { get => RpcProtocol.protocol; }
+        private static readonly global::Avro.Protocol protocol = global::Avro.Protocol.Parse(
         """
         {
           "protocol": "RpcProtocol",
@@ -90,4 +90,4 @@ namespace SchemaNamespace
     
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=record.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial record Record : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -88,4 +88,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=error.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial class Error : global::Avro.Specific.SpecificException
     {
-        public override global::Avro.Schema Schema { get => Error.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "error",
@@ -88,4 +88,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=fixed.verified.txt
@@ -12,8 +12,8 @@ namespace SchemaNamespace
     {
         public Fixed() : base(16) { }
     
-        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",
@@ -61,4 +61,4 @@ namespace SchemaNamespace
         """);
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=protocol#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=protocol#00.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial record Greeting : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Greeting.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Greeting._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -51,4 +51,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=protocol#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=protocol#01.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial class Curse : global::Avro.Specific.SpecificException
     {
-        public override global::Avro.Schema Schema { get => Curse.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Curse._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "error",
@@ -51,4 +51,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=protocol#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=protocol#02.verified.txt
@@ -13,8 +13,8 @@ namespace SchemaNamespace
     
     partial class RpcProtocol : global::Avro.Specific.ISpecificProtocol
     {
-        public global::Avro.Protocol Protocol { get => RpcProtocol.s_protocol; }
-        private static readonly global::Avro.Protocol s_protocol = global::Avro.Protocol.Parse(
+        public global::Avro.Protocol Protocol { get => RpcProtocol.protocol; }
+        private static readonly global::Avro.Protocol protocol = global::Avro.Protocol.Parse(
         """
         {
           "protocol": "RpcProtocol",
@@ -90,4 +90,4 @@ namespace SchemaNamespace
     
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=record.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial record Record : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -88,4 +88,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=error.verified.txt
@@ -10,8 +10,8 @@ namespace SchemaNamespace
     
     partial class Error : global::Avro.Specific.SpecificException
     {
-        public override global::Avro.Schema Schema { get => Error.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         "{\"type\":\"error\",\"name\":\"Error\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}],\"messages\":{\"hello\":{\"doc\":\"Say hello.\",\"request\":[{\"type\":\"Greeting\",\"name\":\"greeting\"}],\"response\":\"Greeting\",\"errors\":[\"Curse\"]}},\"types\":[{\"name\":\"Greeting\",\"type\":\"record\",\"fields\":[{\"type\":\"string\",\"name\":\"message\"}]},{\"name\":\"Curse\",\"type\":\"error\",\"fields\":[{\"type\":\"string\",\"name\":\"message\"}]}]}");
     
         public override object Get(int fieldPos)
@@ -33,4 +33,4 @@ namespace SchemaNamespace
         }
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=fixed.verified.txt
@@ -12,9 +12,9 @@ namespace SchemaNamespace
     {
         public Fixed() : base(16) { }
     
-        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         "{\"type\":\"fixed\",\"name\":\"Fixed\",\"namespace\":\"SchemaNamespace\",\"size\":16,\"messages\":{\"hello\":{\"doc\":\"Say hello.\",\"request\":[{\"type\":\"Greeting\",\"name\":\"greeting\"}],\"response\":\"Greeting\",\"errors\":[\"Curse\"]}},\"types\":[{\"name\":\"Greeting\",\"type\":\"record\",\"fields\":[{\"type\":\"string\",\"name\":\"message\"}]},{\"name\":\"Curse\",\"type\":\"error\",\"fields\":[{\"type\":\"string\",\"name\":\"message\"}]}]}");
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=protocol#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=protocol#00.verified.txt
@@ -10,8 +10,8 @@ namespace SchemaNamespace
     
     partial class Greeting : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Greeting.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Greeting._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Greeting\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"message\",\"type\":\"string\"}]}");
     
         object global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
@@ -33,4 +33,4 @@ namespace SchemaNamespace
         }
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=protocol#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=protocol#01.verified.txt
@@ -10,8 +10,8 @@ namespace SchemaNamespace
     
     partial class Curse : global::Avro.Specific.SpecificException
     {
-        public override global::Avro.Schema Schema { get => Curse.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Curse._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         "{\"type\":\"error\",\"name\":\"Curse\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"message\",\"type\":\"string\"}]}");
     
         public override object Get(int fieldPos)
@@ -33,4 +33,4 @@ namespace SchemaNamespace
         }
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=protocol#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=protocol#02.verified.txt
@@ -13,8 +13,8 @@ namespace SchemaNamespace
     
     partial class RpcProtocol : global::Avro.Specific.ISpecificProtocol
     {
-        public global::Avro.Protocol Protocol { get => RpcProtocol.s_protocol; }
-        private static readonly global::Avro.Protocol s_protocol = global::Avro.Protocol.Parse(
+        public global::Avro.Protocol Protocol { get => RpcProtocol.protocol; }
+        private static readonly global::Avro.Protocol protocol = global::Avro.Protocol.Parse(
         "{\"protocol\":\"RpcProtocol\",\"namespace\":\"SchemaNamespace\",\"types\":[{\"type\":\"record\",\"name\":\"Greeting\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"message\",\"type\":\"string\"}]},{\"type\":\"error\",\"name\":\"Curse\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"message\",\"type\":\"string\"}]}],\"messages\":{\"hello\":{\"doc\":\"Say hello.\",\"request\":[{\"name\":\"greeting\",\"type\":\"Greeting\"}],\"response\":\"Greeting\",\"errors\":[\"Curse\"]}},\"fields\":[{\"type\":\"string\",\"name\":\"Field\"}]}");
     
         public void Request(global::Avro.Specific.ICallbackRequestor requestor, string messageName, object[] args, object callback)
@@ -40,4 +40,4 @@ namespace SchemaNamespace
     
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=record.verified.txt
@@ -10,8 +10,8 @@ namespace SchemaNamespace
     
     partial class Record : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}],\"messages\":{\"hello\":{\"doc\":\"Say hello.\",\"request\":[{\"type\":\"Greeting\",\"name\":\"greeting\"}],\"response\":\"Greeting\",\"errors\":[\"Curse\"]}},\"types\":[{\"name\":\"Greeting\",\"type\":\"record\",\"fields\":[{\"type\":\"string\",\"name\":\"message\"}]},{\"name\":\"Curse\",\"type\":\"error\",\"fields\":[{\"type\":\"string\",\"name\":\"message\"}]}]}");
     
         object global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
@@ -33,4 +33,4 @@ namespace SchemaNamespace
         }
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=error.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial class Error : global::Avro.Specific.SpecificException
     {
-        public override global::Avro.Schema Schema { get => Error.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         "{\"type\":\"error\",\"name\":\"Error\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}],\"messages\":{\"hello\":{\"doc\":\"Say hello.\",\"request\":[{\"type\":\"Greeting\",\"name\":\"greeting\"}],\"response\":\"Greeting\",\"errors\":[\"Curse\"]}},\"types\":[{\"name\":\"Greeting\",\"type\":\"record\",\"fields\":[{\"type\":\"string\",\"name\":\"message\"}]},{\"name\":\"Curse\",\"type\":\"error\",\"fields\":[{\"type\":\"string\",\"name\":\"message\"}]}]}");
     
         public override object? Get(int fieldPos)
@@ -35,4 +35,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=fixed.verified.txt
@@ -12,9 +12,9 @@ namespace SchemaNamespace
     {
         public Fixed() : base(16) { }
     
-        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         "{\"type\":\"fixed\",\"name\":\"Fixed\",\"namespace\":\"SchemaNamespace\",\"size\":16,\"messages\":{\"hello\":{\"doc\":\"Say hello.\",\"request\":[{\"type\":\"Greeting\",\"name\":\"greeting\"}],\"response\":\"Greeting\",\"errors\":[\"Curse\"]}},\"types\":[{\"name\":\"Greeting\",\"type\":\"record\",\"fields\":[{\"type\":\"string\",\"name\":\"message\"}]},{\"name\":\"Curse\",\"type\":\"error\",\"fields\":[{\"type\":\"string\",\"name\":\"message\"}]}]}");
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=protocol#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=protocol#00.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial class Greeting : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Greeting.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Greeting._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Greeting\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"message\",\"type\":\"string\"}]}");
     
         object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
@@ -35,4 +35,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=protocol#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=protocol#01.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial class Curse : global::Avro.Specific.SpecificException
     {
-        public override global::Avro.Schema Schema { get => Curse.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Curse._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         "{\"type\":\"error\",\"name\":\"Curse\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"message\",\"type\":\"string\"}]}");
     
         public override object? Get(int fieldPos)
@@ -35,4 +35,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=protocol#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=protocol#02.verified.txt
@@ -13,8 +13,8 @@ namespace SchemaNamespace
     
     partial class RpcProtocol : global::Avro.Specific.ISpecificProtocol
     {
-        public global::Avro.Protocol Protocol { get => RpcProtocol.s_protocol; }
-        private static readonly global::Avro.Protocol s_protocol = global::Avro.Protocol.Parse(
+        public global::Avro.Protocol Protocol { get => RpcProtocol.protocol; }
+        private static readonly global::Avro.Protocol protocol = global::Avro.Protocol.Parse(
         "{\"protocol\":\"RpcProtocol\",\"namespace\":\"SchemaNamespace\",\"types\":[{\"type\":\"record\",\"name\":\"Greeting\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"message\",\"type\":\"string\"}]},{\"type\":\"error\",\"name\":\"Curse\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"message\",\"type\":\"string\"}]}],\"messages\":{\"hello\":{\"doc\":\"Say hello.\",\"request\":[{\"name\":\"greeting\",\"type\":\"Greeting\"}],\"response\":\"Greeting\",\"errors\":[\"Curse\"]}},\"fields\":[{\"type\":\"string\",\"name\":\"Field\"}]}");
     
         public void Request(global::Avro.Specific.ICallbackRequestor requestor, string messageName, object[] args, object callback)
@@ -40,4 +40,4 @@ namespace SchemaNamespace
     
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=record.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial class Record : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}],\"messages\":{\"hello\":{\"doc\":\"Say hello.\",\"request\":[{\"type\":\"Greeting\",\"name\":\"greeting\"}],\"response\":\"Greeting\",\"errors\":[\"Curse\"]}},\"types\":[{\"name\":\"Greeting\",\"type\":\"record\",\"fields\":[{\"type\":\"string\",\"name\":\"message\"}]},{\"name\":\"Curse\",\"type\":\"error\",\"fields\":[{\"type\":\"string\",\"name\":\"message\"}]}]}");
     
         object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
@@ -35,4 +35,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=error.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial class Error : global::Avro.Specific.SpecificException
     {
-        public override global::Avro.Schema Schema { get => Error.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         "{\"type\":\"error\",\"name\":\"Error\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}],\"messages\":{\"hello\":{\"doc\":\"Say hello.\",\"request\":[{\"type\":\"Greeting\",\"name\":\"greeting\"}],\"response\":\"Greeting\",\"errors\":[\"Curse\"]}},\"types\":[{\"name\":\"Greeting\",\"type\":\"record\",\"fields\":[{\"type\":\"string\",\"name\":\"message\"}]},{\"name\":\"Curse\",\"type\":\"error\",\"fields\":[{\"type\":\"string\",\"name\":\"message\"}]}]}");
     
         public override object? Get(int fieldPos)
@@ -35,4 +35,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=fixed.verified.txt
@@ -12,9 +12,9 @@ namespace SchemaNamespace
     {
         public Fixed() : base(16) { }
     
-        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         "{\"type\":\"fixed\",\"name\":\"Fixed\",\"namespace\":\"SchemaNamespace\",\"size\":16,\"messages\":{\"hello\":{\"doc\":\"Say hello.\",\"request\":[{\"type\":\"Greeting\",\"name\":\"greeting\"}],\"response\":\"Greeting\",\"errors\":[\"Curse\"]}},\"types\":[{\"name\":\"Greeting\",\"type\":\"record\",\"fields\":[{\"type\":\"string\",\"name\":\"message\"}]},{\"name\":\"Curse\",\"type\":\"error\",\"fields\":[{\"type\":\"string\",\"name\":\"message\"}]}]}");
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=protocol#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=protocol#00.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial record Greeting : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Greeting.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Greeting._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Greeting\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"message\",\"type\":\"string\"}]}");
     
         object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
@@ -35,4 +35,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=protocol#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=protocol#01.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial class Curse : global::Avro.Specific.SpecificException
     {
-        public override global::Avro.Schema Schema { get => Curse.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Curse._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         "{\"type\":\"error\",\"name\":\"Curse\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"message\",\"type\":\"string\"}]}");
     
         public override object? Get(int fieldPos)
@@ -35,4 +35,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=protocol#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=protocol#02.verified.txt
@@ -13,8 +13,8 @@ namespace SchemaNamespace
     
     partial class RpcProtocol : global::Avro.Specific.ISpecificProtocol
     {
-        public global::Avro.Protocol Protocol { get => RpcProtocol.s_protocol; }
-        private static readonly global::Avro.Protocol s_protocol = global::Avro.Protocol.Parse(
+        public global::Avro.Protocol Protocol { get => RpcProtocol.protocol; }
+        private static readonly global::Avro.Protocol protocol = global::Avro.Protocol.Parse(
         "{\"protocol\":\"RpcProtocol\",\"namespace\":\"SchemaNamespace\",\"types\":[{\"type\":\"record\",\"name\":\"Greeting\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"message\",\"type\":\"string\"}]},{\"type\":\"error\",\"name\":\"Curse\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"message\",\"type\":\"string\"}]}],\"messages\":{\"hello\":{\"doc\":\"Say hello.\",\"request\":[{\"name\":\"greeting\",\"type\":\"Greeting\"}],\"response\":\"Greeting\",\"errors\":[\"Curse\"]}},\"fields\":[{\"type\":\"string\",\"name\":\"Field\"}]}");
     
         public void Request(global::Avro.Specific.ICallbackRequestor requestor, string messageName, object[] args, object callback)
@@ -40,4 +40,4 @@ namespace SchemaNamespace
     
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=record.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial record Record : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         "{\"type\":\"record\",\"name\":\"Record\",\"namespace\":\"SchemaNamespace\",\"fields\":[{\"name\":\"Field\",\"type\":\"string\"}],\"messages\":{\"hello\":{\"doc\":\"Say hello.\",\"request\":[{\"type\":\"Greeting\",\"name\":\"greeting\"}],\"response\":\"Greeting\",\"errors\":[\"Curse\"]}},\"types\":[{\"name\":\"Greeting\",\"type\":\"record\",\"fields\":[{\"type\":\"string\",\"name\":\"message\"}]},{\"name\":\"Curse\",\"type\":\"error\",\"fields\":[{\"type\":\"string\",\"name\":\"message\"}]}]}");
     
         object? global::Avro.Specific.ISpecificRecord.Get(int fieldPos)
@@ -35,4 +35,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=error.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial class Error : global::Avro.Specific.SpecificException
     {
-        public override global::Avro.Schema Schema { get => Error.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "error",
@@ -88,4 +88,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=fixed.verified.txt
@@ -12,8 +12,8 @@ namespace SchemaNamespace
     {
         public Fixed() : base(16) { }
     
-        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",
@@ -61,4 +61,4 @@ namespace SchemaNamespace
         """);
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=protocol#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=protocol#00.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial record Greeting : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Greeting.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Greeting._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -51,4 +51,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=protocol#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=protocol#01.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial class Curse : global::Avro.Specific.SpecificException
     {
-        public override global::Avro.Schema Schema { get => Curse.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Curse._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "error",
@@ -51,4 +51,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=protocol#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=protocol#02.verified.txt
@@ -13,8 +13,8 @@ namespace SchemaNamespace
     
     partial class RpcProtocol : global::Avro.Specific.ISpecificProtocol
     {
-        public global::Avro.Protocol Protocol { get => RpcProtocol.s_protocol; }
-        private static readonly global::Avro.Protocol s_protocol = global::Avro.Protocol.Parse(
+        public global::Avro.Protocol Protocol { get => RpcProtocol.protocol; }
+        private static readonly global::Avro.Protocol protocol = global::Avro.Protocol.Parse(
         """
         {
           "protocol": "RpcProtocol",
@@ -90,4 +90,4 @@ namespace SchemaNamespace
     
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=record.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial record Record : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -88,4 +88,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.cs
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojLanguageFeaturesTests.cs
@@ -1,4 +1,6 @@
-﻿namespace AvroSourceGenerator.Tests.Apache.Snapshots;
+﻿using AvroSourceGenerator.Templating;
+
+namespace AvroSourceGenerator.Tests.Apache.Snapshots;
 
 public sealed class CsprojLanguageFeaturesTests
 {
@@ -70,5 +72,5 @@ public sealed class CsprojLanguageFeaturesTests
         return Snapshot.Schema(schema, config => config with { LanguageFeatures = languageFeatures });
     }
 
-    public static MatrixTheoryData<string, string> LanguageFeaturesSchemaPairs() => new([.. Enum.GetNames(typeof(AvroSourceGenerator).Assembly.GetType("AvroSourceGenerator.Configuration.LanguageFeatures", throwOnError: true)!).Where(n => n.StartsWith("CSharp")), "invalid"], ["enum", "error", "fixed", "record", "protocol"]);
+    public static MatrixTheoryData<string, string> LanguageFeaturesSchemaPairs() => new([.. Enum.GetNames<LanguageFeatures>().Where(n => n.StartsWith("CSharp")), "invalid"], ["enum", "error", "fixed", "record", "protocol"]);
 }

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=class_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=class_schemaType=error.verified.txt
@@ -10,8 +10,8 @@ namespace SchemaNamespace
     
     partial class Error : global::Avro.Specific.SpecificException
     {
-        public override global::Avro.Schema Schema { get => Error.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "error",
@@ -40,4 +40,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=class_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=class_schemaType=fixed.verified.txt
@@ -12,8 +12,8 @@ namespace SchemaNamespace
     {
         public Fixed() : base(16) { }
     
-        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",
@@ -24,4 +24,4 @@ namespace SchemaNamespace
         """);
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=class_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=class_schemaType=record.verified.txt
@@ -10,8 +10,8 @@ namespace SchemaNamespace
     
     partial class Record : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -40,4 +40,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=invalid_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=invalid_schemaType=error.verified.txt
@@ -10,8 +10,8 @@ namespace SchemaNamespace
     
     partial class Error : global::Avro.Specific.SpecificException
     {
-        public override global::Avro.Schema Schema { get => Error.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "error",
@@ -40,4 +40,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=invalid_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=invalid_schemaType=fixed.verified.txt
@@ -12,8 +12,8 @@ namespace SchemaNamespace
     {
         public Fixed() : base(16) { }
     
-        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",
@@ -24,4 +24,4 @@ namespace SchemaNamespace
         """);
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=invalid_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=invalid_schemaType=record.verified.txt
@@ -10,8 +10,8 @@ namespace SchemaNamespace
     
     partial record Record : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -40,4 +40,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=record_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=record_schemaType=error.verified.txt
@@ -10,8 +10,8 @@ namespace SchemaNamespace
     
     partial class Error : global::Avro.Specific.SpecificException
     {
-        public override global::Avro.Schema Schema { get => Error.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "error",
@@ -40,4 +40,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=record_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=record_schemaType=fixed.verified.txt
@@ -12,8 +12,8 @@ namespace SchemaNamespace
     {
         public Fixed() : base(16) { }
     
-        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",
@@ -24,4 +24,4 @@ namespace SchemaNamespace
         """);
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=record_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=record_schemaType=record.verified.txt
@@ -10,8 +10,8 @@ namespace SchemaNamespace
     
     partial record Record : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -40,4 +40,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojReferenceResolutionTests.Verify_Deferred#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojReferenceResolutionTests.Verify_Deferred#00.verified.txt
@@ -12,8 +12,8 @@ namespace Demo.Store
     
     partial record Order : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Order.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Order._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -88,4 +88,4 @@ namespace Demo.Store
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojReferenceResolutionTests.Verify_Deferred#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojReferenceResolutionTests.Verify_Deferred#01.verified.txt
@@ -11,8 +11,8 @@ namespace Demo.Store
     
     partial record Customer : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Customer.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Customer._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -51,4 +51,4 @@ namespace Demo.Store
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojReferenceResolutionTests.Verify_Deferred#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/CsprojReferenceResolutionTests.Verify_Deferred#02.verified.txt
@@ -12,8 +12,8 @@ namespace Demo.Store
     
     partial record OrderLine : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => OrderLine.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => OrderLine._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -61,4 +61,4 @@ namespace Demo.Store
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FieldEnumTests.Verify_class=error#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FieldEnumTests.Verify_class=error#00.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
         C,
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FieldEnumTests.Verify_class=error#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FieldEnumTests.Verify_class=error#01.verified.txt
@@ -12,8 +12,8 @@ namespace SchemaNamespace
     
     partial class Class : global::Avro.Specific.SpecificException
     {
-        public override global::Avro.Schema Schema { get => Class.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Class._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "error",
@@ -73,4 +73,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FieldEnumTests.Verify_class=record#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FieldEnumTests.Verify_class=record#00.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
         C,
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FieldEnumTests.Verify_class=record#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FieldEnumTests.Verify_class=record#01.verified.txt
@@ -12,8 +12,8 @@ namespace SchemaNamespace
     
     partial record Class : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Class.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Class._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -73,4 +73,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FieldMetadataPropertyTests.Verify_class=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FieldMetadataPropertyTests.Verify_class=error.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial class Class : global::Avro.Specific.SpecificException
     {
-        public override global::Avro.Schema Schema { get => Class.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Class._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "error",
@@ -61,4 +61,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FieldMetadataPropertyTests.Verify_class=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FieldMetadataPropertyTests.Verify_class=record.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial record Class : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Class.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Class._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -61,4 +61,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FixedDocumentationTests.Verify_doc=.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FixedDocumentationTests.Verify_doc=.verified.txt
@@ -12,8 +12,8 @@ namespace SchemaNamespace
     {
         public Fixed() : base(16) { }
     
-        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",
@@ -24,4 +24,4 @@ namespace SchemaNamespace
         """);
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FixedDocumentationTests.Verify_doc=Multi-line-comment.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FixedDocumentationTests.Verify_doc=Multi-line-comment.verified.txt
@@ -17,8 +17,8 @@ namespace SchemaNamespace
     {
         public Fixed() : base(16) { }
     
-        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",
@@ -30,4 +30,4 @@ namespace SchemaNamespace
         """);
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FixedDocumentationTests.Verify_doc=Single line comment.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FixedDocumentationTests.Verify_doc=Single line comment.verified.txt
@@ -15,8 +15,8 @@ namespace SchemaNamespace
     {
         public Fixed() : base(16) { }
     
-        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",
@@ -28,4 +28,4 @@ namespace SchemaNamespace
         """);
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FixedDocumentationTests.Verify_doc=null.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FixedDocumentationTests.Verify_doc=null.verified.txt
@@ -12,8 +12,8 @@ namespace SchemaNamespace
     {
         public Fixed() : base(16) { }
     
-        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",
@@ -24,4 +24,4 @@ namespace SchemaNamespace
         """);
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FixedNameTests.Verify_name=PascalCase.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FixedNameTests.Verify_name=PascalCase.verified.txt
@@ -12,8 +12,8 @@ namespace SchemaNamespace
     {
         public PascalCase() : base(16) { }
     
-        public override global::Avro.Schema Schema { get => PascalCase.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => PascalCase._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",
@@ -24,4 +24,4 @@ namespace SchemaNamespace
         """);
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FixedNameTests.Verify_name=object.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FixedNameTests.Verify_name=object.verified.txt
@@ -12,8 +12,8 @@ namespace SchemaNamespace
     {
         public @object() : base(16) { }
     
-        public override global::Avro.Schema Schema { get => @object.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => @object._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",
@@ -24,4 +24,4 @@ namespace SchemaNamespace
         """);
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FixedNameTests.Verify_name=snake_case.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FixedNameTests.Verify_name=snake_case.verified.txt
@@ -12,8 +12,8 @@ namespace SchemaNamespace
     {
         public snake_case() : base(16) { }
     
-        public override global::Avro.Schema Schema { get => snake_case.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => snake_case._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",
@@ -24,4 +24,4 @@ namespace SchemaNamespace
         """);
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FixedSizeTests.Verify_size=32.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/FixedSizeTests.Verify_size=32.verified.txt
@@ -12,8 +12,8 @@ namespace SchemaNamespace
     {
         public Fixed() : base(32) { }
     
-        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",
@@ -24,4 +24,4 @@ namespace SchemaNamespace
         """);
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/JavaExtensionsTests.Verify.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/JavaExtensionsTests.Verify.verified.txt
@@ -16,8 +16,8 @@ namespace org.apache.parquet.avro
     
     partial record StringBehaviorTest : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => StringBehaviorTest.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => StringBehaviorTest._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -118,4 +118,4 @@ namespace org.apache.parquet.avro
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/LogicalTests.Verify_Date.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/LogicalTests.Verify_Date.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial record Container : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -54,4 +54,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/LogicalTests.Verify_Decimal_Bytes.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/LogicalTests.Verify_Decimal_Bytes.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial record Container : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -56,4 +56,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/LogicalTests.Verify_Decimal_Fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/LogicalTests.Verify_Decimal_Fixed.verified.txt
@@ -12,8 +12,8 @@ namespace SchemaNamespace
     {
         public Decimal() : base(20) { }
     
-        public override global::Avro.Schema Schema { get => Decimal.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Decimal._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",
@@ -26,4 +26,4 @@ namespace SchemaNamespace
         """);
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/LogicalTests.Verify_Duration.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/LogicalTests.Verify_Duration.verified.txt
@@ -12,8 +12,8 @@ namespace SchemaNamespace
     {
         public Duration() : base(12) { }
     
-        public override global::Avro.Schema Schema { get => Duration.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Duration._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",
@@ -24,4 +24,4 @@ namespace SchemaNamespace
         """);
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/LogicalTests.Verify_Local_Timestamp_Microseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/LogicalTests.Verify_Local_Timestamp_Microseconds.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial record Container : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -54,4 +54,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/LogicalTests.Verify_Local_Timestamp_Milliseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/LogicalTests.Verify_Local_Timestamp_Milliseconds.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial record Container : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -54,4 +54,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/LogicalTests.Verify_Time_Microseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/LogicalTests.Verify_Time_Microseconds.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial record Container : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -54,4 +54,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/LogicalTests.Verify_Time_Milliseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/LogicalTests.Verify_Time_Milliseconds.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial record Container : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -54,4 +54,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/LogicalTests.Verify_Timestamp_Microseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/LogicalTests.Verify_Timestamp_Microseconds.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial record Container : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -54,4 +54,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/LogicalTests.Verify_Timestamp_Milliseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/LogicalTests.Verify_Timestamp_Milliseconds.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial record Container : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -54,4 +54,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/LogicalTests.Verify_Uuid_Fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/LogicalTests.Verify_Uuid_Fixed.verified.txt
@@ -12,8 +12,8 @@ namespace SchemaNamespace
     {
         public Uuid() : base(16) { }
     
-        public override global::Avro.Schema Schema { get => Uuid.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Uuid._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",
@@ -24,4 +24,4 @@ namespace SchemaNamespace
         """);
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/LogicalTests.Verify_Uuid_String.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/LogicalTests.Verify_Uuid_String.verified.txt
@@ -11,8 +11,8 @@ namespace SchemaNamespace
     
     partial record Container : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Container._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -54,4 +54,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/MetadataPropertiesTests.Verify_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/MetadataPropertiesTests.Verify_schemaType=error.verified.txt
@@ -10,8 +10,8 @@ namespace SchemaNamespace
     
     partial class Error : global::Avro.Specific.SpecificException
     {
-        public override global::Avro.Schema Schema { get => Error.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Error._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "error",
@@ -44,4 +44,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/MetadataPropertiesTests.Verify_schemaType=fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/MetadataPropertiesTests.Verify_schemaType=fixed.verified.txt
@@ -12,8 +12,8 @@ namespace SchemaNamespace
     {
         public Fixed() : base(16) { }
     
-        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",
@@ -28,4 +28,4 @@ namespace SchemaNamespace
         """);
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/MetadataPropertiesTests.Verify_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/MetadataPropertiesTests.Verify_schemaType=record.verified.txt
@@ -10,8 +10,8 @@ namespace SchemaNamespace
     
     partial record Record : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -44,4 +44,4 @@ namespace SchemaNamespace
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/RecursionTests.Verify_Array.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/RecursionTests.Verify_Array.verified.txt
@@ -11,8 +11,8 @@ namespace ex
     
     partial record A : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => A.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => A._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -54,4 +54,4 @@ namespace ex
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/RecursionTests.Verify_Map.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/RecursionTests.Verify_Map.verified.txt
@@ -11,8 +11,8 @@ namespace ex
     
     partial record A : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => A.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => A._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -54,4 +54,4 @@ namespace ex
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/RecursionTests.Verify_Record#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/RecursionTests.Verify_Record#00.verified.txt
@@ -11,8 +11,8 @@ namespace ex
     
     partial record B : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => B.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => B._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -61,4 +61,4 @@ namespace ex
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/RecursionTests.Verify_Record#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/RecursionTests.Verify_Record#01.verified.txt
@@ -11,8 +11,8 @@ namespace ex
     
     partial record A : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => A.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => A._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -61,4 +61,4 @@ namespace ex
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/RecursionTests.Verify_Union.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/RecursionTests.Verify_Union.verified.txt
@@ -12,8 +12,8 @@ namespace ex
     
     partial record Node : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Node.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Node._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -65,4 +65,4 @@ namespace ex
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/SelfContainedSchemaTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/SelfContainedSchemaTests.Verify#00.verified.txt
@@ -11,8 +11,8 @@ namespace Namespace1
     
     partial record Record1 : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record1.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record1._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -51,4 +51,4 @@ namespace Namespace1
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/SelfContainedSchemaTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/SelfContainedSchemaTests.Verify#01.verified.txt
@@ -14,8 +14,8 @@ namespace Namespace1
     
     partial record Record2 : global::Avro.Specific.ISpecificRecord
     {
-        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record2.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        global::Avro.Schema global::Avro.Specific.ISpecificRecord.Schema { get => Record2._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "record",
@@ -65,4 +65,4 @@ namespace Namespace1
     }
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Apache/Snapshots/UnsupportedLogicalTests.Verify.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Apache/Snapshots/UnsupportedLogicalTests.Verify.verified.txt
@@ -12,8 +12,8 @@ namespace SchemaNamespace
     {
         public Fixed() : base(16) { }
     
-        public override global::Avro.Schema Schema { get => Fixed.s_schema; }
-        private static readonly global::Avro.Schema s_schema = global::Avro.Schema.Parse(
+        public override global::Avro.Schema Schema { get => Fixed._SCHEMA; }
+        public static readonly global::Avro.Schema _SCHEMA = global::Avro.Schema.Parse(
         """
         {
           "type": "fixed",
@@ -24,4 +24,4 @@ namespace SchemaNamespace
         """);
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=error.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=protocol.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=protocol.verified.txt
@@ -8,4 +8,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=record.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=error.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=protocol.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=protocol.verified.txt
@@ -8,4 +8,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=record.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=error.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=protocol.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=protocol.verified.txt
@@ -8,4 +8,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=record.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojDuplicateResolutionTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojDuplicateResolutionTests.Verify#00.verified.txt
@@ -10,4 +10,4 @@ namespace RecordNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojDuplicateResolutionTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojDuplicateResolutionTests.Verify#01.verified.txt
@@ -11,4 +11,4 @@ namespace Schema1Namespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojDuplicateResolutionTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojDuplicateResolutionTests.Verify#02.verified.txt
@@ -11,4 +11,4 @@ namespace Schema2Namespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=error.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=protocol#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=protocol#00.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=protocol#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=protocol#01.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=protocol#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=protocol#02.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=record.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=error.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=protocol#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=protocol#00.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=protocol#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=protocol#01.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=protocol#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=protocol#02.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=record.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=error.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=protocol#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=protocol#00.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=protocol#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=protocol#01.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=protocol#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=protocol#02.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=record.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=error.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=protocol#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=protocol#00.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=protocol#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=protocol#01.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=protocol#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=protocol#02.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=record.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=error.verified.txt
@@ -9,4 +9,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=protocol#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=protocol#00.verified.txt
@@ -9,4 +9,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=protocol#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=protocol#01.verified.txt
@@ -9,4 +9,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=protocol#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=protocol#02.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=record.verified.txt
@@ -9,4 +9,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=error.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=protocol#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=protocol#00.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=protocol#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=protocol#01.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=protocol#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=protocol#02.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=record.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=error.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=protocol#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=protocol#00.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=protocol#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=protocol#01.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=protocol#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=protocol#02.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=record.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=error.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=protocol#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=protocol#00.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=protocol#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=protocol#01.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=protocol#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=protocol#02.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=record.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.cs
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojLanguageFeaturesTests.cs
@@ -1,4 +1,6 @@
-﻿namespace AvroSourceGenerator.Tests.Chr.Snapshots;
+﻿using AvroSourceGenerator.Templating;
+
+namespace AvroSourceGenerator.Tests.Chr.Snapshots;
 
 public sealed class CsprojLanguageFeaturesTests
 {
@@ -69,5 +71,5 @@ public sealed class CsprojLanguageFeaturesTests
         return Snapshot.Schema(schema, config => config with { LanguageFeatures = languageFeatures });
     }
 
-    public static MatrixTheoryData<string, string> LanguageFeaturesSchemaPairs() => new MatrixTheoryData<string, string>([.. Enum.GetNames(typeof(AvroSourceGenerator).Assembly.GetType("AvroSourceGenerator.Configuration.LanguageFeatures", throwOnError: true)!).Where(n => n.StartsWith("CSharp")), "invalid"], ["enum", "error", "record", "protocol"]);
+    public static MatrixTheoryData<string, string> LanguageFeaturesSchemaPairs() => new([.. Enum.GetNames<LanguageFeatures>().Where(n => n.StartsWith("CSharp")), "invalid"], ["enum", "error", "record", "protocol"]);
 }

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=class_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=class_schemaType=error.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=class_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=class_schemaType=record.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=invalid_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=invalid_schemaType=error.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=invalid_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=invalid_schemaType=record.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=record_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=record_schemaType=error.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=record_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=record_schemaType=record.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojReferenceResolutionTests.Verify_Deferred#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojReferenceResolutionTests.Verify_Deferred#00.verified.txt
@@ -12,4 +12,4 @@ namespace Demo.Store
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojReferenceResolutionTests.Verify_Deferred#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojReferenceResolutionTests.Verify_Deferred#01.verified.txt
@@ -11,4 +11,4 @@ namespace Demo.Store
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojReferenceResolutionTests.Verify_Deferred#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/CsprojReferenceResolutionTests.Verify_Deferred#02.verified.txt
@@ -12,4 +12,4 @@ namespace Demo.Store
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/FixedDocumentationTests.Verify_doc=.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/FixedDocumentationTests.Verify_doc=.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/FixedDocumentationTests.Verify_doc=Multi-line-comment.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/FixedDocumentationTests.Verify_doc=Multi-line-comment.verified.txt
@@ -16,4 +16,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/FixedDocumentationTests.Verify_doc=Single line comment.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/FixedDocumentationTests.Verify_doc=Single line comment.verified.txt
@@ -14,4 +14,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/FixedDocumentationTests.Verify_doc=null.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/FixedDocumentationTests.Verify_doc=null.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/LogicalTests.Verify_Date.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/LogicalTests.Verify_Date.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/LogicalTests.Verify_Decimal_Bytes.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/LogicalTests.Verify_Decimal_Bytes.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/LogicalTests.Verify_Decimal_Fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/LogicalTests.Verify_Decimal_Fixed.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/LogicalTests.Verify_Local_Timestamp_Microseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/LogicalTests.Verify_Local_Timestamp_Microseconds.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/LogicalTests.Verify_Local_Timestamp_Milliseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/LogicalTests.Verify_Local_Timestamp_Milliseconds.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/LogicalTests.Verify_Time_Microseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/LogicalTests.Verify_Time_Microseconds.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/LogicalTests.Verify_Time_Milliseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/LogicalTests.Verify_Time_Milliseconds.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/LogicalTests.Verify_Timestamp_Microseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/LogicalTests.Verify_Timestamp_Microseconds.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/LogicalTests.Verify_Timestamp_Milliseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/LogicalTests.Verify_Timestamp_Milliseconds.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/LogicalTests.Verify_Uuid_Fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/LogicalTests.Verify_Uuid_Fixed.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/LogicalTests.Verify_Uuid_String.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/LogicalTests.Verify_Uuid_String.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/RecursionTests.Verify_Array.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/RecursionTests.Verify_Array.verified.txt
@@ -11,4 +11,4 @@ namespace ex
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/RecursionTests.Verify_Map.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/RecursionTests.Verify_Map.verified.txt
@@ -11,4 +11,4 @@ namespace ex
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/RecursionTests.Verify_Record#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/RecursionTests.Verify_Record#00.verified.txt
@@ -11,4 +11,4 @@ namespace ex
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/RecursionTests.Verify_Record#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/RecursionTests.Verify_Record#01.verified.txt
@@ -11,4 +11,4 @@ namespace ex
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/RecursionTests.Verify_Union.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/RecursionTests.Verify_Union.verified.txt
@@ -12,4 +12,4 @@ namespace ex
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/UnionAbstractBaseTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/UnionAbstractBaseTests.Verify#00.verified.txt
@@ -13,4 +13,4 @@ namespace com.example.notifications
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/UnionAbstractBaseTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/UnionAbstractBaseTests.Verify#01.verified.txt
@@ -12,4 +12,4 @@ namespace com.example.notifications
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/UnionAbstractBaseTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/UnionAbstractBaseTests.Verify#02.verified.txt
@@ -13,4 +13,4 @@ namespace com.example.notifications
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/UnionAbstractBaseTests.Verify#03.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/UnionAbstractBaseTests.Verify#03.verified.txt
@@ -55,4 +55,4 @@ namespace com.example.notifications
         }
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/UnionAbstractBaseTests.Verify#04.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/UnionAbstractBaseTests.Verify#04.verified.txt
@@ -22,4 +22,4 @@ namespace com.example.notifications
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/UnionAbstractNullableBaseTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/UnionAbstractNullableBaseTests.Verify#00.verified.txt
@@ -13,4 +13,4 @@ namespace com.example.notifications
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/UnionAbstractNullableBaseTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/UnionAbstractNullableBaseTests.Verify#01.verified.txt
@@ -12,4 +12,4 @@ namespace com.example.notifications
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/UnionAbstractNullableBaseTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/UnionAbstractNullableBaseTests.Verify#02.verified.txt
@@ -13,4 +13,4 @@ namespace com.example.notifications
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/UnionAbstractNullableBaseTests.Verify#03.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/UnionAbstractNullableBaseTests.Verify#03.verified.txt
@@ -58,4 +58,4 @@ namespace com.example.notifications
         }
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests.Chr/Snapshots/UnionAbstractNullableBaseTests.Verify#04.verified.txt
+++ b/tests/AvroSourceGenerator.Tests.Chr/Snapshots/UnionAbstractNullableBaseTests.Verify#04.verified.txt
@@ -23,4 +23,4 @@ namespace com.example.notifications
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=error.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=protocol.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=protocol.verified.txt
@@ -8,4 +8,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=internal_schemaType=record.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=error.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=protocol.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=protocol.verified.txt
@@ -8,4 +8,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=invalid_schemaType=record.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=error.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=protocol.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=protocol.verified.txt
@@ -8,4 +8,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojAccessModifierTests.Verify_accessModifier=public_schemaType=record.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojDuplicateResolutionTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojDuplicateResolutionTests.Verify#00.verified.txt
@@ -10,4 +10,4 @@ namespace RecordNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojDuplicateResolutionTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojDuplicateResolutionTests.Verify#01.verified.txt
@@ -11,4 +11,4 @@ namespace Schema1Namespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojDuplicateResolutionTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojDuplicateResolutionTests.Verify#02.verified.txt
@@ -11,4 +11,4 @@ namespace Schema2Namespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=error.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=protocol#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=protocol#00.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=protocol#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=protocol#01.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=protocol#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=protocol#02.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp10_schemaType=record.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=error.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=protocol#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=protocol#00.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=protocol#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=protocol#01.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=protocol#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=protocol#02.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp11_schemaType=record.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=error.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=protocol#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=protocol#00.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=protocol#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=protocol#01.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=protocol#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=protocol#02.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp12_schemaType=record.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=error.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=protocol#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=protocol#00.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=protocol#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=protocol#01.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=protocol#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=protocol#02.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp13_schemaType=record.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=error.verified.txt
@@ -9,4 +9,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=protocol#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=protocol#00.verified.txt
@@ -9,4 +9,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=protocol#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=protocol#01.verified.txt
@@ -9,4 +9,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=protocol#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=protocol#02.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp7_3_schemaType=record.verified.txt
@@ -9,4 +9,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=error.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=protocol#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=protocol#00.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=protocol#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=protocol#01.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=protocol#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=protocol#02.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp8_schemaType=record.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=error.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=protocol#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=protocol#00.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=protocol#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=protocol#01.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=protocol#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=protocol#02.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=CSharp9_schemaType=record.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=error.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=protocol#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=protocol#00.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=protocol#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=protocol#01.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=protocol#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=protocol#02.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojLanguageFeaturesTests.Verify_languageFeatures=invalid_schemaType=record.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=class_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=class_schemaType=error.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=class_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=class_schemaType=record.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=invalid_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=invalid_schemaType=error.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=invalid_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=invalid_schemaType=record.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=record_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=record_schemaType=error.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=record_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojRecordDeclarationTests.Verify_recordDeclaration=record_schemaType=record.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojReferenceResolutionTests.Verify_Deferred#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojReferenceResolutionTests.Verify_Deferred#00.verified.txt
@@ -12,4 +12,4 @@ namespace Demo.Store
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojReferenceResolutionTests.Verify_Deferred#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojReferenceResolutionTests.Verify_Deferred#01.verified.txt
@@ -11,4 +11,4 @@ namespace Demo.Store
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/CsprojReferenceResolutionTests.Verify_Deferred#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/CsprojReferenceResolutionTests.Verify_Deferred#02.verified.txt
@@ -12,4 +12,4 @@ namespace Demo.Store
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=Multi-line-comment_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=Multi-line-comment_schemaType=enum.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=Multi-line-comment_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=Multi-line-comment_schemaType=error.verified.txt
@@ -15,4 +15,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=Multi-line-comment_schemaType=protocol.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=Multi-line-comment_schemaType=protocol.verified.txt
@@ -13,4 +13,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=Multi-line-comment_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=Multi-line-comment_schemaType=record.verified.txt
@@ -15,4 +15,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=Single line comment_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=Single line comment_schemaType=enum.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=Single line comment_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=Single line comment_schemaType=error.verified.txt
@@ -13,4 +13,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=Single line comment_schemaType=protocol.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=Single line comment_schemaType=protocol.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=Single line comment_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=Single line comment_schemaType=record.verified.txt
@@ -13,4 +13,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=_schemaType=error.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=_schemaType=protocol.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=_schemaType=protocol.verified.txt
@@ -8,4 +8,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=_schemaType=record.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=null_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=null_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=null_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=null_schemaType=error.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=null_schemaType=protocol.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=null_schemaType=protocol.verified.txt
@@ -8,4 +8,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=null_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/DocumentationTests.Verify_doc=null_schemaType=record.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/EnumSymbolsTests.Verify_symbols=A,B.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/EnumSymbolsTests.Verify_symbols=A,B.verified.txt
@@ -9,4 +9,4 @@ namespace SchemaNamespace
         B,
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/EnumSymbolsTests.Verify_symbols=[].verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/EnumSymbolsTests.Verify_symbols=[].verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldCollectionTests.Verify_class=error_field=array-string-.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldCollectionTests.Verify_class=error_field=array-string-.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldCollectionTests.Verify_class=error_field=map-string-.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldCollectionTests.Verify_class=error_field=map-string-.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldCollectionTests.Verify_class=record_field=array-string-.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldCollectionTests.Verify_class=record_field=array-string-.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldCollectionTests.Verify_class=record_field=map-string-.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldCollectionTests.Verify_class=record_field=map-string-.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldDefaultTests.Verify_schemaType=boolean_defaultValue=true.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldDefaultTests.Verify_schemaType=boolean_defaultValue=true.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldDefaultTests.Verify_schemaType=bytes_defaultValue=-NDI=-.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldDefaultTests.Verify_schemaType=bytes_defaultValue=-NDI=-.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldDefaultTests.Verify_schemaType=double_defaultValue=42.0.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldDefaultTests.Verify_schemaType=double_defaultValue=42.0.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldDefaultTests.Verify_schemaType=enum-A,B,C-_defaultValue=-B-#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldDefaultTests.Verify_schemaType=enum-A,B,C-_defaultValue=-B-#00.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
         C,
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldDefaultTests.Verify_schemaType=enum-A,B,C-_defaultValue=-B-#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldDefaultTests.Verify_schemaType=enum-A,B,C-_defaultValue=-B-#01.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldDefaultTests.Verify_schemaType=float_defaultValue=42.0.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldDefaultTests.Verify_schemaType=float_defaultValue=42.0.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldDefaultTests.Verify_schemaType=int_defaultValue=42.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldDefaultTests.Verify_schemaType=int_defaultValue=42.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldDefaultTests.Verify_schemaType=long_defaultValue=42.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldDefaultTests.Verify_schemaType=long_defaultValue=42.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldDefaultTests.Verify_schemaType=null_defaultValue=null.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldDefaultTests.Verify_schemaType=null_defaultValue=null.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldDefaultTests.Verify_schemaType=string_defaultValue=-FortyTwo-.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldDefaultTests.Verify_schemaType=string_defaultValue=-FortyTwo-.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldEnumTests.Verify_class=error#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldEnumTests.Verify_class=error#00.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
         C,
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldEnumTests.Verify_class=error#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldEnumTests.Verify_class=error#01.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldEnumTests.Verify_class=record#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldEnumTests.Verify_class=record#00.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
         C,
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldEnumTests.Verify_class=record#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldEnumTests.Verify_class=record#01.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=error_field=boolean.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=error_field=boolean.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=error_field=bytes.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=error_field=bytes.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=error_field=double.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=error_field=double.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=error_field=float.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=error_field=float.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=error_field=int.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=error_field=int.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=error_field=long.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=error_field=long.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=error_field=null.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=error_field=null.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=error_field=string.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=error_field=string.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=record_field=boolean.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=record_field=boolean.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=record_field=bytes.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=record_field=bytes.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=record_field=double.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=record_field=double.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=record_field=float.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=record_field=float.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=record_field=int.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=record_field=int.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=record_field=long.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=record_field=long.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=record_field=null.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=record_field=null.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=record_field=string.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FieldPrimitiveTests.Verify_class=record_field=string.verified.txt
@@ -12,4 +12,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FixedDocumentationTests.Verify_doc=.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FixedDocumentationTests.Verify_doc=.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FixedDocumentationTests.Verify_doc=Multi-line-comment.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FixedDocumentationTests.Verify_doc=Multi-line-comment.verified.txt
@@ -16,4 +16,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FixedDocumentationTests.Verify_doc=Single line comment.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FixedDocumentationTests.Verify_doc=Single line comment.verified.txt
@@ -14,4 +14,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FixedDocumentationTests.Verify_doc=null.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FixedDocumentationTests.Verify_doc=null.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FullNameTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FullNameTests.Verify#00.verified.txt
@@ -9,4 +9,4 @@
         a,
         b,
     }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FullNameTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FullNameTests.Verify#01.verified.txt
@@ -13,4 +13,4 @@ namespace @explicit
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FullNameTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FullNameTests.Verify#02.verified.txt
@@ -12,4 +12,4 @@ namespace a.full
         e,
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FullNameTests.Verify#03.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FullNameTests.Verify#03.verified.txt
@@ -14,4 +14,4 @@ namespace a.full
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/FullNameTests.Verify#04.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/FullNameTests.Verify#04.verified.txt
@@ -13,4 +13,4 @@
     }
     
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/JavaExtensionsTests.Verify.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/JavaExtensionsTests.Verify.verified.txt
@@ -16,4 +16,4 @@ namespace org.apache.parquet.avro
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests.Verify_Date.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests.Verify_Date.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests.Verify_Decimal_Bytes.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests.Verify_Decimal_Bytes.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests.Verify_Decimal_Fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests.Verify_Decimal_Fixed.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests.Verify_Local_Timestamp_Microseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests.Verify_Local_Timestamp_Microseconds.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests.Verify_Local_Timestamp_Milliseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests.Verify_Local_Timestamp_Milliseconds.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests.Verify_Time_Microseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests.Verify_Time_Microseconds.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests.Verify_Time_Milliseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests.Verify_Time_Milliseconds.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests.Verify_Timestamp_Microseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests.Verify_Timestamp_Microseconds.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests.Verify_Timestamp_Milliseconds.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests.Verify_Timestamp_Milliseconds.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests.Verify_Uuid_Fixed.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests.Verify_Uuid_Fixed.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests.Verify_Uuid_String.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/LogicalTests.Verify_Uuid_String.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NameTests.Verify_name=PascalCase_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NameTests.Verify_name=PascalCase_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NameTests.Verify_name=PascalCase_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NameTests.Verify_name=PascalCase_schemaType=error.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NameTests.Verify_name=PascalCase_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NameTests.Verify_name=PascalCase_schemaType=record.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NameTests.Verify_name=object_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NameTests.Verify_name=object_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NameTests.Verify_name=object_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NameTests.Verify_name=object_schemaType=error.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NameTests.Verify_name=object_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NameTests.Verify_name=object_schemaType=record.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NameTests.Verify_name=snake_case_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NameTests.Verify_name=snake_case_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace SchemaNamespace
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NameTests.Verify_name=snake_case_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NameTests.Verify_name=snake_case_schemaType=error.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NameTests.Verify_name=snake_case_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NameTests.Verify_name=snake_case_schemaType=record.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests.Verify_namespace=PascalCase.snake_case.object_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests.Verify_namespace=PascalCase.snake_case.object_schemaType=enum.verified.txt
@@ -7,4 +7,4 @@ namespace PascalCase.snake_case.@object
     {
     }
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests.Verify_namespace=PascalCase.snake_case.object_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests.Verify_namespace=PascalCase.snake_case.object_schemaType=error.verified.txt
@@ -10,4 +10,4 @@ namespace PascalCase.snake_case.@object
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests.Verify_namespace=PascalCase.snake_case.object_schemaType=protocol.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests.Verify_namespace=PascalCase.snake_case.object_schemaType=protocol.verified.txt
@@ -8,4 +8,4 @@ namespace PascalCase.snake_case.@object
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests.Verify_namespace=PascalCase.snake_case.object_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests.Verify_namespace=PascalCase.snake_case.object_schemaType=record.verified.txt
@@ -10,4 +10,4 @@ namespace PascalCase.snake_case.@object
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests.Verify_namespace=_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests.Verify_namespace=_schemaType=enum.verified.txt
@@ -4,4 +4,4 @@
     public enum Enum
     {
     }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests.Verify_namespace=_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests.Verify_namespace=_schemaType=error.verified.txt
@@ -7,4 +7,4 @@
     }
     
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests.Verify_namespace=_schemaType=protocol.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests.Verify_namespace=_schemaType=protocol.verified.txt
@@ -5,4 +5,4 @@
     {
     }
     
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests.Verify_namespace=_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests.Verify_namespace=_schemaType=record.verified.txt
@@ -7,4 +7,4 @@
     }
     
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests.Verify_namespace=null_schemaType=enum.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests.Verify_namespace=null_schemaType=enum.verified.txt
@@ -4,4 +4,4 @@
     public enum Enum
     {
     }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests.Verify_namespace=null_schemaType=error.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests.Verify_namespace=null_schemaType=error.verified.txt
@@ -7,4 +7,4 @@
     }
     
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests.Verify_namespace=null_schemaType=protocol.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests.Verify_namespace=null_schemaType=protocol.verified.txt
@@ -5,4 +5,4 @@
     {
     }
     
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests.Verify_namespace=null_schemaType=record.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/NamespaceTests.Verify_namespace=null_schemaType=record.verified.txt
@@ -7,4 +7,4 @@
     }
     
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/ProtocolNameTests.Verify_name=PascalCase.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/ProtocolNameTests.Verify_name=PascalCase.verified.txt
@@ -8,4 +8,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/ProtocolNameTests.Verify_name=object.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/ProtocolNameTests.Verify_name=object.verified.txt
@@ -8,4 +8,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/ProtocolNameTests.Verify_name=snake_case.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/ProtocolNameTests.Verify_name=snake_case.verified.txt
@@ -8,4 +8,4 @@ namespace SchemaNamespace
     }
     
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/RecursionTests.Verify_Array.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/RecursionTests.Verify_Array.verified.txt
@@ -11,4 +11,4 @@ namespace ex
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/RecursionTests.Verify_Map.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/RecursionTests.Verify_Map.verified.txt
@@ -11,4 +11,4 @@ namespace ex
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/RecursionTests.Verify_Record#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/RecursionTests.Verify_Record#00.verified.txt
@@ -11,4 +11,4 @@ namespace ex
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/RecursionTests.Verify_Record#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/RecursionTests.Verify_Record#01.verified.txt
@@ -11,4 +11,4 @@ namespace ex
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/RecursionTests.Verify_Union.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/RecursionTests.Verify_Union.verified.txt
@@ -12,4 +12,4 @@ namespace ex
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/SchemaReferenceTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/SchemaReferenceTests.Verify#00.verified.txt
@@ -10,4 +10,4 @@ namespace This.Is.A.Full
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/SchemaReferenceTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/SchemaReferenceTests.Verify#01.verified.txt
@@ -14,4 +14,4 @@ namespace This.Is.A.Full
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/SchemaReferenceTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/SchemaReferenceTests.Verify#02.verified.txt
@@ -13,4 +13,4 @@
     }
     
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/SchemaRegistryDuplicateResolutionTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/SchemaRegistryDuplicateResolutionTests.Verify#00.verified.txt
@@ -10,4 +10,4 @@ namespace Demo
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/SchemaRegistryDuplicateResolutionTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/SchemaRegistryDuplicateResolutionTests.Verify#01.verified.txt
@@ -12,4 +12,4 @@ namespace Demo
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/SchemaRegistryRootSchemaValidationTests.Verify_schemaType=[null, record].verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/SchemaRegistryRootSchemaValidationTests.Verify_schemaType=[null, record].verified.txt
@@ -10,4 +10,4 @@ namespace Demo
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/SchemaRegistryRootSchemaValidationTests.Verify_schemaType=array-record-.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/SchemaRegistryRootSchemaValidationTests.Verify_schemaType=array-record-.verified.txt
@@ -10,4 +10,4 @@ namespace Demo
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/SchemaRegistryRootSchemaValidationTests.Verify_schemaType=map-record-.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/SchemaRegistryRootSchemaValidationTests.Verify_schemaType=map-record-.verified.txt
@@ -10,4 +10,4 @@ namespace Demo
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionAbstractBaseTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionAbstractBaseTests.Verify#00.verified.txt
@@ -13,4 +13,4 @@ namespace com.example.notifications
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionAbstractBaseTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionAbstractBaseTests.Verify#01.verified.txt
@@ -12,4 +12,4 @@ namespace com.example.notifications
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionAbstractBaseTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionAbstractBaseTests.Verify#02.verified.txt
@@ -13,4 +13,4 @@ namespace com.example.notifications
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionAbstractBaseTests.Verify#03.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionAbstractBaseTests.Verify#03.verified.txt
@@ -13,4 +13,4 @@ namespace com.example.notifications
     [global::System.CodeDom.Compiler.GeneratedCode("AvroSourceGenerator", "1.0.0.0")]
     public partial interface INotificationContentVariant;
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionAbstractBaseTests.Verify#04.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionAbstractBaseTests.Verify#04.verified.txt
@@ -22,4 +22,4 @@ namespace com.example.notifications
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionAbstractNullableBaseTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionAbstractNullableBaseTests.Verify#00.verified.txt
@@ -13,4 +13,4 @@ namespace com.example.notifications
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionAbstractNullableBaseTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionAbstractNullableBaseTests.Verify#01.verified.txt
@@ -12,4 +12,4 @@ namespace com.example.notifications
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionAbstractNullableBaseTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionAbstractNullableBaseTests.Verify#02.verified.txt
@@ -13,4 +13,4 @@ namespace com.example.notifications
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionAbstractNullableBaseTests.Verify#03.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionAbstractNullableBaseTests.Verify#03.verified.txt
@@ -14,4 +14,4 @@ namespace com.example.notifications
     [global::System.CodeDom.Compiler.GeneratedCode("AvroSourceGenerator", "1.0.0.0")]
     public partial interface INotificationContentVariant;
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionAbstractNullableBaseTests.Verify#04.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionAbstractNullableBaseTests.Verify#04.verified.txt
@@ -23,4 +23,4 @@ namespace com.example.notifications
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionObjectBaseTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionObjectBaseTests.Verify#00.verified.txt
@@ -13,4 +13,4 @@ namespace com.example.notifications
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionObjectBaseTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionObjectBaseTests.Verify#01.verified.txt
@@ -12,4 +12,4 @@ namespace com.example.notifications
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionObjectBaseTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionObjectBaseTests.Verify#02.verified.txt
@@ -13,4 +13,4 @@ namespace com.example.notifications
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionObjectBaseTests.Verify#03.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionObjectBaseTests.Verify#03.verified.txt
@@ -14,4 +14,4 @@ namespace com.example.notifications
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionObjectNullableBaseTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionObjectNullableBaseTests.Verify#00.verified.txt
@@ -13,4 +13,4 @@ namespace com.example.notifications
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionObjectNullableBaseTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionObjectNullableBaseTests.Verify#01.verified.txt
@@ -12,4 +12,4 @@ namespace com.example.notifications
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionObjectNullableBaseTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionObjectNullableBaseTests.Verify#02.verified.txt
@@ -13,4 +13,4 @@ namespace com.example.notifications
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionObjectNullableBaseTests.Verify#03.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionObjectNullableBaseTests.Verify#03.verified.txt
@@ -14,4 +14,4 @@ namespace com.example.notifications
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionRootAbstractTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionRootAbstractTests.Verify#00.verified.txt
@@ -10,4 +10,4 @@
     }
     
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionRootAbstractTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionRootAbstractTests.Verify#01.verified.txt
@@ -9,4 +9,4 @@
     }
     
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionRootAbstractTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionRootAbstractTests.Verify#02.verified.txt
@@ -10,4 +10,4 @@
     }
     
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionRootObjectTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionRootObjectTests.Verify#00.verified.txt
@@ -8,4 +8,4 @@
     }
     
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionRootObjectTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionRootObjectTests.Verify#01.verified.txt
@@ -10,4 +10,4 @@
     }
     
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionRootObjectTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionRootObjectTests.Verify#02.verified.txt
@@ -9,4 +9,4 @@
     }
     
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionRootObjectTests.Verify#03.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionRootObjectTests.Verify#03.verified.txt
@@ -10,4 +10,4 @@
     }
     
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionWithNullTests.Verify#00.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionWithNullTests.Verify#00.verified.txt
@@ -12,4 +12,4 @@ namespace com.example.user
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionWithNullTests.Verify#01.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionWithNullTests.Verify#01.verified.txt
@@ -13,4 +13,4 @@ namespace com.example.user
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionWithNullTests.Verify#02.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionWithNullTests.Verify#02.verified.txt
@@ -12,4 +12,4 @@ namespace com.example.user
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionWithNullTests.Verify#03.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionWithNullTests.Verify#03.verified.txt
@@ -11,4 +11,4 @@ namespace com.example.user
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionWithNullTests.Verify#04.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionWithNullTests.Verify#04.verified.txt
@@ -11,4 +11,4 @@ namespace com.example.user
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionWithNullTests.Verify#05.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionWithNullTests.Verify#05.verified.txt
@@ -13,4 +13,4 @@ namespace com.example.user
     [global::System.CodeDom.Compiler.GeneratedCode("AvroSourceGenerator", "1.0.0.0")]
     public partial interface IUserProfileContactVariant;
 }
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnionWithNullTests.Verify#06.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnionWithNullTests.Verify#06.verified.txt
@@ -41,4 +41,4 @@ namespace com.example.user
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnnamedRootSchemasTests.Verify_schemaType=[null, record].verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnnamedRootSchemasTests.Verify_schemaType=[null, record].verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnnamedRootSchemasTests.Verify_schemaType=array-record-.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnnamedRootSchemasTests.Verify_schemaType=array-record-.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnnamedRootSchemasTests.Verify_schemaType=map-record-.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnnamedRootSchemasTests.Verify_schemaType=map-record-.verified.txt
@@ -10,4 +10,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981

--- a/tests/AvroSourceGenerator.Tests/Snapshots/UnsupportedLogicalTests.Verify.verified.txt
+++ b/tests/AvroSourceGenerator.Tests/Snapshots/UnsupportedLogicalTests.Verify.verified.txt
@@ -11,4 +11,4 @@ namespace SchemaNamespace
     
 }
 #nullable restore
-#pragma warning restore CS8618, CS8633, CS8714, CS8775
+#pragma warning restore CS8618, CS8633, CS8714, CS8775, CS8981


### PR DESCRIPTION
- Schema templates now use public static readonly global::Avro.Schema _SCHEMA.
- Protocol template now uses private static readonly global::Avro.Protocol protocol.
- Schema template now correctly restores CS8981.
- Fixes some tests trying to reflect moved types.