### PR TITLE
Refactor schema model and align field order handling

### DIFF
--- a/src/AvroSourceGenerator.Core/Avsc/JsonElementJsonExtensions.cs
+++ b/src/AvroSourceGenerator.Core/Avsc/JsonElementJsonExtensions.cs
@@ -43,20 +43,6 @@ internal static class JsonElementJsonExtensions
         public string? GetOptionalString(string propertyName) =>
             schema.GetOptionalProperty(propertyName)?.ToOptionalString();
 
-        public int? GetNullableInt32(string propertyName)
-        {
-            var maybeJson = schema.GetNullableProperty(propertyName);
-            if (maybeJson is null or { ValueKind: JsonValueKind.Null or JsonValueKind.Undefined }) return null;
-
-            var json = maybeJson.Value;
-            if (json.ValueKind is JsonValueKind.Null) return null;
-
-            if (json.ValueKind is not JsonValueKind.Number || !json.TryGetInt32(out var value))
-                throw new InvalidSchemaException($"'{propertyName}' property must be an integer (found '{schema.GetNullableProperty(propertyName)}') in schema: {schema.GetRawText()}");
-
-            return value;
-        }
-
         public JsonElement.ArrayEnumerator GetRequiredArray(string propertyName)
         {
             var json = schema.GetRequiredProperty(propertyName);

--- a/src/AvroSourceGenerator.Core/Avsc/SchemaRegistrySchemaExtensions.cs
+++ b/src/AvroSourceGenerator.Core/Avsc/SchemaRegistrySchemaExtensions.cs
@@ -18,24 +18,10 @@ public static class SchemaRegistrySchemaExtensions
             using (schemaRegistry.EnterRegisterScope())
             {
                 var registeredSchema = schemaRegistry.Schema(schema, containingNamespace: null);
-                if (!ContainsTopLevelSchema(registeredSchema))
+                if (!registeredSchema.ContainsTopLevelSchema())
                 {
                     throw new InvalidSchemaException($"At least a named schema must be present in schema: {schema.GetRawText()}");
                 }
-            }
-
-            // ReSharper disable once SeparateLocalFunctionsWithJumpStatement
-            static bool ContainsTopLevelSchema(AvroSchema schema)
-            {
-                return schema switch
-                {
-                    TopLevelSchema => true,
-                    ArraySchema array => ContainsTopLevelSchema(array.ItemSchema),
-                    MapSchema map => ContainsTopLevelSchema(map.ValueSchema),
-                    UnionSchema union => union.Schemas.Any(ContainsTopLevelSchema),
-                    LogicalSchema logical => ContainsTopLevelSchema(logical.UnderlyingSchema),
-                    _ => false
-                };
             }
         }
 
@@ -137,7 +123,7 @@ public static class SchemaRegistrySchemaExtensions
                 var @default = schema.GetNullableString(AvroJsonKeys.Default);
                 var properties = schema.GetSchemaProperties();
 
-                var enumSchema = new EnumSchema(schema, schemaName, documentation, aliases, symbols, @default, properties);
+                var enumSchema = new EnumSchema(schemaName, documentation, aliases, symbols, @default, properties);
                 schemaRegistry.Register(enumSchema);
                 return enumSchema;
             }
@@ -156,8 +142,8 @@ public static class SchemaRegistrySchemaExtensions
                 var fixedSchema = schemaRegistry.Options.TargetProfile switch
                 {
                     // Only Apache.Avro needs a custom type for fixed, others use byte[].
-                    TargetProfile.Apache => new FixedSchema(schema, schemaName, documentation, aliases, size, properties),
-                    _ => FixedSchema.CreateAsByteArray(schema, schemaName, documentation, aliases, size, properties),
+                    TargetProfile.Apache => new FixedSchema(schemaName, documentation, aliases, size, properties),
+                    _ => FixedSchema.CreateAsByteArray(schemaName, documentation, aliases, size, properties),
                 };
                 schemaRegistry.Register(fixedSchema);
                 return fixedSchema;
@@ -174,7 +160,7 @@ public static class SchemaRegistrySchemaExtensions
                 var fields = schemaRegistry.Fields(schema, schemaName);
                 var properties = schema.GetSchemaProperties();
 
-                var errorSchema = new ErrorSchema(schema, schemaName, documentation, aliases, fields, properties);
+                var errorSchema = new ErrorSchema(schemaName, documentation, aliases, fields, properties);
                 schemaRegistry.Register(errorSchema);
                 return errorSchema;
             }
@@ -190,7 +176,7 @@ public static class SchemaRegistrySchemaExtensions
                 var fields = schemaRegistry.Fields(schema, schemaName);
                 var properties = schema.GetSchemaProperties();
 
-                var recordSchema = new RecordSchema(schema, schemaName, documentation, aliases, fields, properties);
+                var recordSchema = new RecordSchema(schemaName, documentation, aliases, fields, properties);
                 schemaRegistry.Register(recordSchema);
                 return recordSchema;
             }
@@ -245,7 +231,7 @@ public static class SchemaRegistrySchemaExtensions
             var aliases = field.GetAliases();
             var defaultJson = field.GetNullableProperty(AvroJsonKeys.Default);
             var @default = type.GetValue(defaultJson);
-            var order = field.GetNullableInt32(AvroJsonKeys.Order);
+            var order = field.GetOptionalString(AvroJsonKeys.Order);
             var properties = field.GetSchemaProperties();
 
             return new Field(name, type, underlyingType, isNullable, documentation, aliases, defaultJson, @default, order, properties, remarks);
@@ -301,7 +287,7 @@ public static class SchemaRegistrySchemaExtensions
                 var messages = schemaRegistry.ProtocolMessages(schema.GetRequiredObject(AvroJsonKeys.Messages), schemaName.Namespace);
                 var properties = schema.GetProtocolProperties();
 
-                var protocolSchema = new ProtocolSchema(schema, schemaName, documentation, types, messages, properties);
+                var protocolSchema = new ProtocolSchema(schemaName, documentation, types, messages, properties);
 
                 schemaRegistry.Register(protocolSchema);
 
@@ -340,13 +326,13 @@ public static class SchemaRegistrySchemaExtensions
             return protocolMessages.ToImmutable();
         }
 
-        private ProtocolMessage Message(JsonProperty property, string? containingNamespace)
+        private ProtocolMessage Message(JsonProperty message, string? containingNamespace)
         {
-            var methodName = property.Name.ToValidName();
-            var documentation = property.Value.GetDocumentation();
-            var requestParameters = schemaRegistry.ProtocolRequestParameters(property.Value, containingNamespace);
-            var response = schemaRegistry.ProtocolResponse(property.Value.GetRequiredProperty(AvroJsonKeys.Response), containingNamespace);
-            var errors = schemaRegistry.ProtocolErrors(property.Value.GetNullableArray(AvroJsonKeys.Errors), containingNamespace);
+            var methodName = message.Name.ToValidName();
+            var documentation = message.Value.GetDocumentation();
+            var requestParameters = schemaRegistry.ProtocolRequestParameters(message.Value, containingNamespace);
+            var response = schemaRegistry.ProtocolResponse(message.Value.GetRequiredProperty(AvroJsonKeys.Response), containingNamespace);
+            var errors = schemaRegistry.ProtocolErrors(message.Value.GetNullableArray(AvroJsonKeys.Errors), containingNamespace);
             return new ProtocolMessage(methodName, documentation, requestParameters, response, errors);
         }
 
@@ -359,10 +345,10 @@ public static class SchemaRegistrySchemaExtensions
             return fields.ToImmutable();
         }
 
-        private ProtocolRequestParameter ProtocolRequestParameter(JsonElement field, string? containingNamespace)
+        private ProtocolRequestParameter ProtocolRequestParameter(JsonElement parameter, string? containingNamespace)
         {
-            var name = field.GetRequiredString(AvroJsonKeys.Name).ToValidName();
-            var type = schemaRegistry.Schema(field.GetRequiredProperty(AvroJsonKeys.Type), containingNamespace);
+            var name = parameter.GetRequiredString(AvroJsonKeys.Name).ToValidName();
+            var type = schemaRegistry.Schema(parameter.GetRequiredProperty(AvroJsonKeys.Type), containingNamespace);
             var underlyingType = type;
             var isNullable = false;
             if (type is UnionSchema union)
@@ -371,8 +357,8 @@ public static class SchemaRegistrySchemaExtensions
                 underlyingType = union.UnderlyingSchema;
             }
 
-            var documentation = field.GetDocumentation();
-            var defaultJson = field.GetNullableProperty(AvroJsonKeys.Default);
+            var documentation = parameter.GetDocumentation();
+            var defaultJson = parameter.GetNullableProperty(AvroJsonKeys.Default);
             var @default = type.GetValue(defaultJson);
             return new ProtocolRequestParameter(name, type, underlyingType, isNullable, documentation, defaultJson, @default);
         }
@@ -393,12 +379,12 @@ public static class SchemaRegistrySchemaExtensions
 
         private ImmutableArray<AvroSchema> ProtocolErrors(JsonElement.ArrayEnumerator? errors, string? containingNamespace)
         {
-            var builder = ImmutableArray.CreateBuilder<AvroSchema>();
             if (errors is null)
             {
-                return builder.ToImmutable();
+                return [];
             }
 
+            var builder = ImmutableArray.CreateBuilder<AvroSchema>();
             foreach (var error in errors.Value)
             {
                 builder.Add(schemaRegistry.Schema(error, containingNamespace));

--- a/src/AvroSourceGenerator.Core/Extensions/AvroSchemaExtensions.cs
+++ b/src/AvroSourceGenerator.Core/Extensions/AvroSchemaExtensions.cs
@@ -3,10 +3,23 @@ using AvroSourceGenerator.Schemas;
 
 namespace AvroSourceGenerator.Extensions;
 
-internal static class GetValueExtensions
+internal static class AvroSchemaExtensions
 {
     extension(AvroSchema schema)
     {
+        public bool ContainsTopLevelSchema()
+        {
+            return schema switch
+            {
+                TopLevelSchema => true,
+                ArraySchema array => array.ItemSchema.ContainsTopLevelSchema(),
+                MapSchema map => map.ValueSchema.ContainsTopLevelSchema(),
+                UnionSchema union => union.Schemas.Any(ContainsTopLevelSchema),
+                LogicalSchema logical => logical.UnderlyingSchema.ContainsTopLevelSchema(),
+                _ => false
+            };
+        }
+
         // TODO: This should probably be in AvroSchema hierarchy instead of being here.
         public string? GetValue(JsonElement? json)
         {

--- a/src/AvroSourceGenerator.Core/Protocols/ProtocolSchema.cs
+++ b/src/AvroSourceGenerator.Core/Protocols/ProtocolSchema.cs
@@ -1,17 +1,16 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Text.Json;
 using AvroSourceGenerator.Schemas;
 
 namespace AvroSourceGenerator.Protocols;
 
 public sealed record class ProtocolSchema(
-    JsonElement Json,
     SchemaName SchemaName,
     string? Documentation,
     ImmutableArray<NamedSchema> Types,
     ImmutableArray<ProtocolMessage> Messages,
     ImmutableSortedDictionary<string, JsonElement> Properties)
-    : TopLevelSchema(SchemaType.Protocol, Json, SchemaName, Documentation, Properties)
+    : TopLevelSchema(SchemaType.Protocol, SchemaName, Documentation, Properties)
 {
     public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {

--- a/src/AvroSourceGenerator.Core/Schemas/ArraySchema.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/ArraySchema.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 namespace AvroSourceGenerator.Schemas;
 
 public sealed record class ArraySchema(AvroSchema ItemSchema, string? Documentation, ImmutableSortedDictionary<string, JsonElement> Properties)
-    : AvroSchema(SchemaType.Array, GetCSharpName(ItemSchema), new SchemaName(AvroTypeNames.Array), Documentation, Properties)
+    : AvroSchema(SchemaType.Array, new SchemaName(AvroTypeNames.Array), GetCSharpName(ItemSchema), Documentation, Properties)
 {
     public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {
@@ -21,5 +21,5 @@ public sealed record class ArraySchema(AvroSchema ItemSchema, string? Documentat
         writer.WriteEndObject();
     }
 
-    private static CSharpName GetCSharpName(AvroSchema itemSchema) => new CSharpName($"List<{itemSchema}>", "System.Collections.Generic");
+    private static CSharpName GetCSharpName(AvroSchema itemSchema) => new($"List<{itemSchema}>", "System.Collections.Generic");
 }

--- a/src/AvroSourceGenerator.Core/Schemas/AvroSchema.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/AvroSchema.cs
@@ -6,8 +6,8 @@ namespace AvroSourceGenerator.Schemas;
 
 public abstract record class AvroSchema(
     SchemaType Type,
-    CSharpName CSharpName,
     SchemaName SchemaName,
+    CSharpName CSharpName,
     string? Documentation,
     ImmutableSortedDictionary<string, JsonElement> Properties)
 {
@@ -27,12 +27,12 @@ public abstract record class AvroSchema(
 
     public abstract void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace);
 
-    public static readonly PrimitiveSchema Object = new PrimitiveSchema(SchemaType.Null, new CSharpName("object"), new SchemaName(AvroTypeNames.Null));
-    public static readonly PrimitiveSchema Boolean = new PrimitiveSchema(SchemaType.Boolean, new CSharpName("bool"), new SchemaName(AvroTypeNames.Boolean));
-    public static readonly PrimitiveSchema Int = new PrimitiveSchema(SchemaType.Int, new CSharpName("int"), new SchemaName(AvroTypeNames.Int));
-    public static readonly PrimitiveSchema Long = new PrimitiveSchema(SchemaType.Long, new CSharpName("long"), new SchemaName(AvroTypeNames.Long));
-    public static readonly PrimitiveSchema Float = new PrimitiveSchema(SchemaType.Float, new CSharpName("float"), new SchemaName(AvroTypeNames.Float));
-    public static readonly PrimitiveSchema Double = new PrimitiveSchema(SchemaType.Double, new CSharpName("double"), new SchemaName(AvroTypeNames.Double));
-    public static readonly PrimitiveSchema Bytes = new PrimitiveSchema(SchemaType.Bytes, new CSharpName("byte[]"), new SchemaName(AvroTypeNames.Bytes));
-    public static readonly PrimitiveSchema String = new PrimitiveSchema(SchemaType.String, new CSharpName("string"), new SchemaName(AvroTypeNames.String));
+    public static readonly PrimitiveSchema Object = new(SchemaType.Null, new CSharpName("object"), new SchemaName(AvroTypeNames.Null));
+    public static readonly PrimitiveSchema Boolean = new(SchemaType.Boolean, new CSharpName("bool"), new SchemaName(AvroTypeNames.Boolean));
+    public static readonly PrimitiveSchema Int = new(SchemaType.Int, new CSharpName("int"), new SchemaName(AvroTypeNames.Int));
+    public static readonly PrimitiveSchema Long = new(SchemaType.Long, new CSharpName("long"), new SchemaName(AvroTypeNames.Long));
+    public static readonly PrimitiveSchema Float = new(SchemaType.Float, new CSharpName("float"), new SchemaName(AvroTypeNames.Float));
+    public static readonly PrimitiveSchema Double = new(SchemaType.Double, new CSharpName("double"), new SchemaName(AvroTypeNames.Double));
+    public static readonly PrimitiveSchema Bytes = new(SchemaType.Bytes, new CSharpName("byte[]"), new SchemaName(AvroTypeNames.Bytes));
+    public static readonly PrimitiveSchema String = new(SchemaType.String, new CSharpName("string"), new SchemaName(AvroTypeNames.String));
 }

--- a/src/AvroSourceGenerator.Core/Schemas/AvroSchemaReference.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/AvroSchemaReference.cs
@@ -3,9 +3,11 @@ using System.Text.Json;
 
 namespace AvroSourceGenerator.Schemas;
 
-public sealed record class AvroSchemaReference(SchemaName SchemaName)
-    : AvroSchema(SchemaType.Reference, CSharpName.FromSchemaName(SchemaName), SchemaName, Documentation: null, ImmutableSortedDictionary<string, JsonElement>.Empty)
+public sealed record class AvroSchemaReference(SchemaName SchemaName, CSharpName CSharpName)
+    : AvroSchema(SchemaType.Reference, SchemaName, CSharpName, Documentation: null, Properties: ImmutableSortedDictionary<string, JsonElement>.Empty)
 {
+    public AvroSchemaReference(SchemaName SchemaName) : this(SchemaName, CSharpName.FromSchemaName(SchemaName)) { }
+
     public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {
         if (writtenSchemas.Contains(SchemaName))

--- a/src/AvroSourceGenerator.Core/Schemas/CSharpName.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/CSharpName.cs
@@ -12,5 +12,5 @@ public readonly record struct CSharpName(string Name, string? Namespace)
 
     public string ToString(bool includeGlobalPrefix) => includeGlobalPrefix || !FullName.StartsWith("global::") ? FullName : FullName[8..];
 
-    public static CSharpName FromSchemaName(SchemaName schemaName) => new CSharpName(schemaName.Name.ToValidName(), schemaName.Namespace?.ToValidNamespace());
+    public static CSharpName FromSchemaName(SchemaName schemaName) => new(schemaName.Name.ToValidName(), schemaName.Namespace?.ToValidNamespace());
 }

--- a/src/AvroSourceGenerator.Core/Schemas/EnumSchema.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/EnumSchema.cs
@@ -4,14 +4,13 @@ using System.Text.Json;
 namespace AvroSourceGenerator.Schemas;
 
 public sealed record class EnumSchema(
-    JsonElement Json,
     SchemaName SchemaName,
     string? Documentation,
     ImmutableArray<string> Aliases,
     ImmutableArray<string> Symbols,
     string? Default,
     ImmutableSortedDictionary<string, JsonElement> Properties)
-    : NamedSchema(SchemaType.Enum, Json, SchemaName, Documentation, Aliases, Properties)
+    : NamedSchema(SchemaType.Enum, SchemaName, Documentation, Aliases, Properties)
 {
     public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {

--- a/src/AvroSourceGenerator.Core/Schemas/ErrorSchema.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/ErrorSchema.cs
@@ -4,13 +4,12 @@ using System.Text.Json;
 namespace AvroSourceGenerator.Schemas;
 
 public sealed record class ErrorSchema(
-    JsonElement Json,
     SchemaName SchemaName,
     string? Documentation,
     ImmutableArray<string> Aliases,
     ImmutableArray<Field> Fields,
     ImmutableSortedDictionary<string, JsonElement> Properties)
-    : NamedSchema(SchemaType.Error, Json, SchemaName, Documentation, Aliases, Properties)
+    : NamedSchema(SchemaType.Error, SchemaName, Documentation, Aliases, Properties)
 {
     public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {

--- a/src/AvroSourceGenerator.Core/Schemas/Field.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/Field.cs
@@ -12,7 +12,7 @@ public sealed record class Field(
     ImmutableArray<string> Aliases,
     JsonElement? DefaultJson,
     object? Default,
-    int? Order,
+    string? Order,
     ImmutableSortedDictionary<string, JsonElement> Properties,
     string? Remarks)
 {
@@ -38,6 +38,11 @@ public sealed record class Field(
             writer.WritePropertyName(AvroJsonKeys.Default);
             DefaultJson.Value.WriteTo(writer);
         }
+
+        // Apache.Avro drops field order when CodeGen re-emits a schema. This is probably
+        // an upstream bug, but our generated schema text intentionally stays in sync.
+        // if (Order is not null)
+        //     writer.WriteString(AvroJsonKeys.Order, Order);
 
         foreach (var entry in Properties)
         {

--- a/src/AvroSourceGenerator.Core/Schemas/FixedSchema.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/FixedSchema.cs
@@ -4,23 +4,21 @@ using System.Text.Json;
 namespace AvroSourceGenerator.Schemas;
 
 public sealed record class FixedSchema(
-    JsonElement Json,
     SchemaName SchemaName,
     string? Documentation,
     ImmutableArray<string> Aliases,
     int Size,
     ImmutableSortedDictionary<string, JsonElement> Properties)
-    : NamedSchema(SchemaType.Fixed, Json, SchemaName, Documentation, Aliases, Properties)
+    : NamedSchema(SchemaType.Fixed, SchemaName, Documentation, Aliases, Properties)
 {
     public static FixedSchema CreateAsByteArray(
-        JsonElement json,
         SchemaName schemaName,
         string? documentation,
         ImmutableArray<string> aliases,
         int size,
         ImmutableSortedDictionary<string, JsonElement> properties)
     {
-        return new FixedSchema(json, schemaName, documentation, aliases, size, properties)
+        return new FixedSchema(schemaName, documentation, aliases, size, properties)
         {
             CSharpName = Bytes.CSharpName,
         };

--- a/src/AvroSourceGenerator.Core/Schemas/LogicalSchema.ForApache.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/LogicalSchema.ForApache.cs
@@ -8,40 +8,40 @@ internal static partial class LogicalSchemaExtensions
         {
             LogicalTypeNames.Date => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("DateTime", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("DateTime", "System")),
             LogicalTypeNames.Decimal when underlyingSchema.Type is SchemaType.Bytes => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("AvroDecimal", "Avro"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("AvroDecimal", "Avro")),
             LogicalTypeNames.TimeMicros => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("TimeSpan", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("TimeSpan", "System")),
             LogicalTypeNames.TimeMillis => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("TimeSpan", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("TimeSpan", "System")),
             LogicalTypeNames.TimestampMicros => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("DateTime", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("DateTime", "System")),
             LogicalTypeNames.TimestampMillis => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("DateTime", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("DateTime", "System")),
             LogicalTypeNames.LocalTimestampMicros => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("DateTime", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("DateTime", "System")),
             LogicalTypeNames.LocalTimestampMillis => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("DateTime", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("DateTime", "System")),
             LogicalTypeNames.Uuid when underlyingSchema.Type is SchemaType.String => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("Guid", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("Guid", "System")),
 
             // TODO: Language implementations must ignore unknown logical types when reading, and should use the underlying Avro type.
             // Apache.Avro will throw an exception when it encounters an unknown logical type, which is not compliant.

--- a/src/AvroSourceGenerator.Core/Schemas/LogicalSchema.ForChr.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/LogicalSchema.ForChr.cs
@@ -8,44 +8,44 @@ internal static partial class LogicalSchemaExtensions
         {
             LogicalTypeNames.Date => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("DateOnly", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("DateOnly", "System")),
             LogicalTypeNames.Decimal => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("decimal"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("decimal")),
             LogicalTypeNames.Duration => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("TimeSpan", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("TimeSpan", "System")),
             LogicalTypeNames.TimeMicros => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("TimeOnly", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("TimeOnly", "System")),
             LogicalTypeNames.TimeMillis => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("TimeOnly", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("TimeOnly", "System")),
             LogicalTypeNames.TimestampMicros => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("DateTimeOffset", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("DateTimeOffset", "System")),
             LogicalTypeNames.TimestampMillis => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("DateTimeOffset", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("DateTimeOffset", "System")),
             LogicalTypeNames.LocalTimestampMicros => new LogicalSchema(
                 underlyingSchema,
-                underlyingSchema.CSharpName,
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                underlyingSchema.CSharpName),
             LogicalTypeNames.LocalTimestampMillis => new LogicalSchema(
                 underlyingSchema,
-                underlyingSchema.CSharpName,
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                underlyingSchema.CSharpName),
             LogicalTypeNames.Uuid => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("Guid", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("Guid", "System")),
             _ => underlyingSchema,
         };
     }

--- a/src/AvroSourceGenerator.Core/Schemas/LogicalSchema.ForLegacy.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/LogicalSchema.ForLegacy.cs
@@ -8,44 +8,44 @@ internal static partial class LogicalSchemaExtensions
         {
             LogicalTypeNames.Date => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("DateTime", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("DateTime", "System")),
             LogicalTypeNames.Decimal => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("decimal"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("decimal")),
             LogicalTypeNames.Duration => new LogicalSchema(
                 underlyingSchema,
-                underlyingSchema.CSharpName,
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                underlyingSchema.CSharpName),
             LogicalTypeNames.TimeMicros => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("TimeSpan", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("TimeSpan", "System")),
             LogicalTypeNames.TimeMillis => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("TimeSpan", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("TimeSpan", "System")),
             LogicalTypeNames.TimestampMicros => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("DateTime", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("DateTime", "System")),
             LogicalTypeNames.TimestampMillis => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("DateTime", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("DateTime", "System")),
             LogicalTypeNames.LocalTimestampMicros => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("DateTime", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("DateTime", "System")),
             LogicalTypeNames.LocalTimestampMillis => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("DateTime", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("DateTime", "System")),
             LogicalTypeNames.Uuid => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("Guid", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("Guid", "System")),
             _ => underlyingSchema,
         };
     }

--- a/src/AvroSourceGenerator.Core/Schemas/LogicalSchema.ForModern.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/LogicalSchema.ForModern.cs
@@ -8,44 +8,44 @@ internal static partial class LogicalSchemaExtensions
         {
             LogicalTypeNames.Date => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("DateOnly", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("DateOnly", "System")),
             LogicalTypeNames.Decimal => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("decimal"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("decimal")),
             LogicalTypeNames.Duration => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("TimeSpan", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("TimeSpan", "System")),
             LogicalTypeNames.TimeMicros => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("TimeOnly", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("TimeOnly", "System")),
             LogicalTypeNames.TimeMillis => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("TimeOnly", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("TimeOnly", "System")),
             LogicalTypeNames.TimestampMicros => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("DateTimeOffset", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("DateTimeOffset", "System")),
             LogicalTypeNames.TimestampMillis => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("DateTimeOffset", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("DateTimeOffset", "System")),
             LogicalTypeNames.LocalTimestampMicros => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("DateTimeOffset", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("DateTimeOffset", "System")),
             LogicalTypeNames.LocalTimestampMillis => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("DateTimeOffset", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("DateTimeOffset", "System")),
             LogicalTypeNames.Uuid => new LogicalSchema(
                 underlyingSchema,
-                new CSharpName("Guid", "System"),
-                new SchemaName(logicalType)),
+                new SchemaName(logicalType),
+                new CSharpName("Guid", "System")),
             _ => underlyingSchema,
         };
     }

--- a/src/AvroSourceGenerator.Core/Schemas/LogicalSchema.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/LogicalSchema.cs
@@ -5,9 +5,9 @@ namespace AvroSourceGenerator.Schemas;
 
 public sealed record class LogicalSchema(
     AvroSchema UnderlyingSchema,
-    CSharpName CSharpName,
-    SchemaName SchemaName)
-    : AvroSchema(SchemaType.Logical, CSharpName, SchemaName, UnderlyingSchema.Documentation, UnderlyingSchema.Properties)
+    SchemaName SchemaName,
+    CSharpName CSharpName)
+    : AvroSchema(SchemaType.Logical, SchemaName, CSharpName, UnderlyingSchema.Documentation, UnderlyingSchema.Properties)
 {
     public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {

--- a/src/AvroSourceGenerator.Core/Schemas/MapSchema.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/MapSchema.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 namespace AvroSourceGenerator.Schemas;
 
 public sealed record class MapSchema(AvroSchema ValueSchema, string? Documentation, ImmutableSortedDictionary<string, JsonElement> Properties)
-    : AvroSchema(SchemaType.Map, GetCSharpName(ValueSchema), new SchemaName(AvroTypeNames.Map), Documentation, Properties)
+    : AvroSchema(SchemaType.Map, new SchemaName(AvroTypeNames.Map), GetCSharpName(ValueSchema), Documentation, Properties)
 {
     public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {
@@ -21,5 +21,5 @@ public sealed record class MapSchema(AvroSchema ValueSchema, string? Documentati
         writer.WriteEndObject();
     }
 
-    private static CSharpName GetCSharpName(AvroSchema valueSchema) => new CSharpName($"Dictionary<string, {valueSchema}>", "System.Collections.Generic");
+    private static CSharpName GetCSharpName(AvroSchema valueSchema) => new($"Dictionary<string, {valueSchema}>", "System.Collections.Generic");
 }

--- a/src/AvroSourceGenerator.Core/Schemas/NamedSchema.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/NamedSchema.cs
@@ -5,9 +5,8 @@ namespace AvroSourceGenerator.Schemas;
 
 public abstract record class NamedSchema(
     SchemaType Type,
-    JsonElement Json,
     SchemaName SchemaName,
     string? Documentation,
     ImmutableArray<string> Aliases,
     ImmutableSortedDictionary<string, JsonElement> Properties)
-    : TopLevelSchema(Type, Json, SchemaName, Documentation, Properties);
+    : TopLevelSchema(Type, SchemaName, Documentation, Properties);

--- a/src/AvroSourceGenerator.Core/Schemas/PrimitiveSchema.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/PrimitiveSchema.cs
@@ -3,11 +3,11 @@ using System.Text.Json;
 
 namespace AvroSourceGenerator.Schemas;
 
-public sealed record class PrimitiveSchema(SchemaType Type, CSharpName CSharpName, SchemaName SchemaName, string? Documentation, ImmutableSortedDictionary<string, JsonElement> Properties)
-    : AvroSchema(Type, CSharpName, SchemaName, Documentation, Properties)
+public sealed record class PrimitiveSchema(SchemaType Type, SchemaName SchemaName, CSharpName CSharpName, string? Documentation, ImmutableSortedDictionary<string, JsonElement> Properties)
+    : AvroSchema(Type, SchemaName, CSharpName, Documentation, Properties)
 {
     public PrimitiveSchema(SchemaType type, CSharpName csharpName, SchemaName schemaName)
-        : this(type, csharpName, schemaName, Documentation: null, ImmutableSortedDictionary<string, JsonElement>.Empty) { }
+        : this(type, schemaName, csharpName, Documentation: null, Properties: ImmutableSortedDictionary<string, JsonElement>.Empty) { }
 
     public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {

--- a/src/AvroSourceGenerator.Core/Schemas/RecordSchema.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/RecordSchema.cs
@@ -4,13 +4,12 @@ using System.Text.Json;
 namespace AvroSourceGenerator.Schemas;
 
 public sealed record class RecordSchema(
-    JsonElement Json,
     SchemaName SchemaName,
     string? Documentation,
     ImmutableArray<string> Aliases,
     ImmutableArray<Field> Fields,
     ImmutableSortedDictionary<string, JsonElement> Properties)
-    : NamedSchema(SchemaType.Record, Json, SchemaName, Documentation, Aliases, Properties)
+    : NamedSchema(SchemaType.Record, SchemaName, Documentation, Aliases, Properties)
 {
     public AvroSchema? InheritsFrom { get; set; }
 

--- a/src/AvroSourceGenerator.Core/Schemas/TopLevelSchema.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/TopLevelSchema.cs
@@ -5,8 +5,7 @@ namespace AvroSourceGenerator.Schemas;
 
 public abstract record class TopLevelSchema(
     SchemaType Type,
-    JsonElement Json,
     SchemaName SchemaName,
     string? Documentation,
     ImmutableSortedDictionary<string, JsonElement> Properties)
-    : AvroSchema(Type, CSharpName.FromSchemaName(SchemaName), SchemaName, Documentation, Properties);
+    : AvroSchema(Type, SchemaName, CSharpName.FromSchemaName(SchemaName), Documentation, Properties);

--- a/src/AvroSourceGenerator.Core/Schemas/UnionSchema.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/UnionSchema.cs
@@ -8,7 +8,7 @@ public sealed record class UnionSchema(
     ImmutableArray<AvroSchema> Schemas,
     AvroSchema UnderlyingSchema,
     bool IsNullable)
-    : AvroSchema(SchemaType.Union, CSharpName, new SchemaName(string.Empty), Documentation: null, ImmutableSortedDictionary<string, JsonElement>.Empty)
+    : AvroSchema(SchemaType.Union, new SchemaName(string.Empty), CSharpName, Documentation: null, Properties: ImmutableSortedDictionary<string, JsonElement>.Empty)
 {
     public override void WriteTo(Utf8JsonWriter writer, IReadOnlyDictionary<SchemaName, TopLevelSchema> registeredSchemas, HashSet<SchemaName> writtenSchemas, string? containingNamespace)
     {

--- a/src/AvroSourceGenerator.Core/Schemas/VariantSchema.cs
+++ b/src/AvroSourceGenerator.Core/Schemas/VariantSchema.cs
@@ -8,7 +8,6 @@ public sealed record class VariantSchema(
     ImmutableArray<AvroSchema> DerivedSchemas)
     : TopLevelSchema(
         SchemaType.Variant,
-        default,
         SchemaName,
         GetDefaultDocumentation(DerivedSchemas),
         ImmutableSortedDictionary<string, JsonElement>.Empty)

--- a/src/AvroSourceGenerator/Inputs/AvroFile.cs
+++ b/src/AvroSourceGenerator/Inputs/AvroFile.cs
@@ -47,4 +47,9 @@ internal static class AvroFile
             return AvroInvalidFile.Invalid(path, text, ex);
         }
     }
+
+    extension(IAvroFile file)
+    {
+        public bool IsValid => !file.Diagnostics.Any(d => d.Descriptor.DefaultSeverity is DiagnosticSeverity.Error);
+    }
 }

--- a/src/AvroSourceGenerator/Output/GeneratorOutput.cs
+++ b/src/AvroSourceGenerator/Output/GeneratorOutput.cs
@@ -58,6 +58,9 @@ internal readonly record struct GeneratorOutput(ImmutableArray<RenderedSchema> S
             {
                 switch (file)
                 {
+                    case { IsValid: false }:
+                        break;
+
                     case AvroSchemaFile schemaFile:
                         schemaRegistry.RegisterSchema(schema: schemaFile.Json);
                         break;

--- a/tests/AvroSourceGenerator.Tests.Apache/Bugs/FieldOrderCodeGenCompatibilityTests.cs
+++ b/tests/AvroSourceGenerator.Tests.Apache/Bugs/FieldOrderCodeGenCompatibilityTests.cs
@@ -1,0 +1,33 @@
+namespace AvroSourceGenerator.Tests.Apache.Bugs;
+
+public sealed class FieldOrderCodeGenCompatibilityTests
+{
+    [Fact]
+    public void Apache_CodeGen_drops_field_order_from_generated_schema()
+    {
+        const string SchemaJson =
+            """
+            {
+              "type": "record",
+              "name": "Person",
+              "namespace": "Example",
+              "fields": [
+                {
+                  "name": "name",
+                  "type": "string",
+                  "order": "descending"
+                }
+              ]
+            }
+            """;
+
+        var codeGen = new Avro.CodeGen();
+        codeGen.AddSchema(SchemaJson);
+
+        codeGen.GenerateCode();
+        var generatedCode = codeGen.GetTypes().Single().Value;
+
+        Assert.Contains("\\\"name\\\":\\\"name\\\"", generatedCode);
+        Assert.DoesNotContain("\\\"order\\\":\\\"descending\\\"", generatedCode);
+    }
+}

--- a/tests/AvroSourceGenerator.Tests/SchemaRegistryFindTests.cs
+++ b/tests/AvroSourceGenerator.Tests/SchemaRegistryFindTests.cs
@@ -87,15 +87,6 @@ public sealed class SchemaRegistryFindTests
 
     private static RecordSchema CreateRecord(string name, string? @namespace) =>
         new(
-            Json: Parse(
-                $$"""
-                {
-                  "type": "record",
-                  "name": "{{name}}",
-                  "namespace": "{{@namespace}}",
-                  "fields": []
-                }
-                """),
             SchemaName: new SchemaName(name, @namespace),
             Documentation: null,
             Aliases: [],


### PR DESCRIPTION
Remove stored raw JSON from top-level schema records and centralize schema helpers for top-level schema detection and default value conversion.

Also parse Avro field order as a string, document why it is intentionally omitted when writing generated schema text, and add an Apache CodeGen compatibility test for the dropped field order behavior.