### PR TITLE
Improve AVDL parser recovery

### DIFF
--- a/src/AvroSourceGenerator.Core/Avdl/Diagnostics/SyntaxDiagnostic.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Diagnostics/SyntaxDiagnostic.cs
@@ -7,7 +7,7 @@ public readonly record struct SyntaxDiagnostic(SyntaxDiagnosticCode Code, Source
 
 internal static class SyntaxDiagnosticExtensions
 {
-    private static string? GetDisplayText(SyntaxKind syntaxKind) => SyntaxFacts.GetText(syntaxKind) ?? syntaxKind.ToString();
+    private static string? GetDisplayText(SyntaxKind syntaxKind) => SyntaxFacts.GetDisplayText(syntaxKind) ?? syntaxKind.ToString();
 
     extension(SyntaxDiagnostic)
     {
@@ -32,8 +32,14 @@ internal static class SyntaxDiagnosticExtensions
         public static SyntaxDiagnostic UnterminatedVerbatimIdentifier(SourceSpan sourceSpan) =>
             new(SyntaxDiagnosticCode.UnterminatedVerbatimIdentifier, sourceSpan, "Unterminated verbatim identifier");
 
-        public static SyntaxDiagnostic UnexpectedToken(SyntaxKind expected, SyntaxToken actual) =>
-            new(SyntaxDiagnosticCode.UnexpectedToken, actual.SourceSpan, $"Unexpected token '{actual.ValueText}'. Expected '{GetDisplayText(expected)}'");
+        public static SyntaxDiagnostic UnexpectedToken(SyntaxKind expected, SyntaxToken actual)
+        {
+            var actualValueText = actual.ValueText;
+            var actualDisplayText = SyntaxFacts.GetDisplayText(actual.SyntaxKind);
+            return actualDisplayText is not null && actualDisplayText != actualValueText
+                ? new SyntaxDiagnostic(SyntaxDiagnosticCode.UnexpectedToken, actual.SourceSpan, $"Unexpected token '{actualValueText}' ({actualDisplayText}). Expected '{GetDisplayText(expected)}'")
+                : new SyntaxDiagnostic(SyntaxDiagnosticCode.UnexpectedToken, actual.SourceSpan, $"Unexpected token '{actualValueText}'. Expected '{GetDisplayText(expected)}'");
+        }
 
         public static SyntaxDiagnostic UnexpectedJsonValue(SyntaxToken actual) =>
             new(SyntaxDiagnosticCode.UnexpectedJsonValue, actual.SourceSpan, $"Unexpected JSON value token '{actual.ValueText}'");

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/FieldDeclarationSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/FieldDeclarationSyntax.cs
@@ -10,7 +10,7 @@ public sealed record class FieldDeclarationSyntax(
     SyntaxList<IAnnotationSyntax> Annotations,
     DefaultValueClauseSyntax? DefaultValueClause,
     SyntaxToken SemicolonToken)
-    : ISyntaxNode
+    : IDeclarationSyntax
 {
     public SyntaxKind SyntaxKind => SyntaxKind.FieldDeclaration;
 

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/IDeclarationSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/IDeclarationSyntax.cs
@@ -1,3 +1,10 @@
-﻿namespace AvroSourceGenerator.Avdl.Syntax.Declarations;
+﻿using AvroSourceGenerator.Avdl.Syntax.Annotations;
 
-public interface IDeclarationSyntax : ISyntaxNode;
+namespace AvroSourceGenerator.Avdl.Syntax.Declarations;
+
+public interface IDeclarationSyntax : ISyntaxNode
+{
+    SimpleNameSyntax Name { get; }
+    SyntaxList<DocumentationSyntax> Documentation { get; }
+    SyntaxList<IAnnotationSyntax> Annotations { get; }
+}

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/ISchemaDeclarationSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/ISchemaDeclarationSyntax.cs
@@ -1,3 +1,3 @@
 ﻿namespace AvroSourceGenerator.Avdl.Syntax.Declarations;
 
-public interface ISchemaDeclarationSyntax : IDeclarationSyntax;
+public interface ISchemaDeclarationSyntax : ITopLevelDeclarationSyntax;

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/ITopLevelDeclarationSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/ITopLevelDeclarationSyntax.cs
@@ -1,0 +1,3 @@
+﻿namespace AvroSourceGenerator.Avdl.Syntax.Declarations;
+
+public interface ITopLevelDeclarationSyntax : IDeclarationSyntax;

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/MessageDeclarationSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/MessageDeclarationSyntax.cs
@@ -1,4 +1,4 @@
-using AvroSourceGenerator.Avdl.Syntax.Annotations;
+﻿using AvroSourceGenerator.Avdl.Syntax.Annotations;
 using AvroSourceGenerator.Avdl.Syntax.Types;
 
 namespace AvroSourceGenerator.Avdl.Syntax.Declarations;
@@ -14,7 +14,7 @@ public sealed record class MessageDeclarationSyntax(
     OneWayClauseSyntax? OneWayClause,
     ThrowsErrorClauseSyntax? ThrowsErrorClause,
     SyntaxToken SemicolonToken)
-    : ISyntaxNode
+    : IDeclarationSyntax
 {
     public SyntaxKind SyntaxKind => SyntaxKind.MessageDeclaration;
 

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/ParameterDeclarationSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/ParameterDeclarationSyntax.cs
@@ -1,9 +1,15 @@
-﻿using AvroSourceGenerator.Avdl.Syntax.Types;
+﻿using AvroSourceGenerator.Avdl.Syntax.Annotations;
+using AvroSourceGenerator.Avdl.Syntax.Types;
 
 namespace AvroSourceGenerator.Avdl.Syntax.Declarations;
 
-public sealed record class ParameterDeclarationSyntax(ITypeSyntax Type, SimpleNameSyntax Name, DefaultValueClauseSyntax? DefaultValueClause)
-    : ISyntaxNode
+public sealed record class ParameterDeclarationSyntax(
+    ITypeSyntax Type,
+    SimpleNameSyntax Name,
+    SyntaxList<DocumentationSyntax> Documentation,
+    SyntaxList<IAnnotationSyntax> Annotations,
+    DefaultValueClauseSyntax? DefaultValueClause)
+    : IDeclarationSyntax
 {
     public SyntaxKind SyntaxKind => SyntaxKind.ParameterDeclaration;
 
@@ -11,6 +17,10 @@ public sealed record class ParameterDeclarationSyntax(ITypeSyntax Type, SimpleNa
     {
         yield return Type;
         yield return Name;
+        foreach (var documentation in Documentation)
+            yield return documentation;
+        foreach (var annotation in Annotations)
+            yield return annotation;
         if (DefaultValueClause is not null)
         {
             yield return DefaultValueClause;

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/ProtocolDeclarationSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Declarations/ProtocolDeclarationSyntax.cs
@@ -13,7 +13,7 @@ public sealed record class ProtocolDeclarationSyntax(
     SyntaxList<ISchemaDeclarationSyntax> Types,
     SyntaxList<MessageDeclarationSyntax> Messages,
     SyntaxToken BraceCloseToken)
-    : IDeclarationSyntax
+    : ITopLevelDeclarationSyntax
 {
     public SyntaxKind SyntaxKind => SyntaxKind.ProtocolDeclaration;
 

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/DocumentSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/DocumentSyntax.cs
@@ -5,10 +5,16 @@ namespace AvroSourceGenerator.Avdl.Syntax;
 
 public sealed record class DocumentSyntax(
     SyntaxList<IDirectiveSyntax> Directives,
-    SyntaxList<IDeclarationSyntax> Declarations
+    SyntaxList<ITopLevelDeclarationSyntax> Declarations
 ) : ISyntaxNode
 {
     public SyntaxKind SyntaxKind => SyntaxKind.Document;
+
+    public NamespaceDirectiveSyntax? NamespaceDirective => Directives.OfType<NamespaceDirectiveSyntax>().SingleOrDefault();
+
+    public SchemaDirectiveSyntax? SchemaDirective => Directives.OfType<SchemaDirectiveSyntax>().SingleOrDefault();
+
+    public IEnumerable<ImportDirectiveSyntax> ImportDirectives => Directives.OfType<ImportDirectiveSyntax>();
 
     public IEnumerable<ISyntaxNode> Children()
     {

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Parser.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Parser.cs
@@ -84,9 +84,9 @@ public sealed class Parser(SourceText sourceText)
         return new ImportDirectiveSyntax(importKeyword, importTypeKeyword, importPathLiteralToken, semicolonToken);
     }
 
-    private SyntaxList<IDeclarationSyntax> ParseDeclarations()
+    private SyntaxList<ITopLevelDeclarationSyntax> ParseDeclarations()
     {
-        var declarations = ImmutableArray.CreateBuilder<IDeclarationSyntax>();
+        var declarations = ImmutableArray.CreateBuilder<ITopLevelDeclarationSyntax>();
         while (!_stream.IsAtEnd)
         {
             EnqueueMetadata();
@@ -95,13 +95,16 @@ public sealed class Parser(SourceText sourceText)
                 break;
             }
 
-            declarations.Add(ParseDeclaration());
+            using (EnsureProgress())
+            {
+                declarations.Add(ParseDeclaration());
+            }
         }
 
-        return new SyntaxList<IDeclarationSyntax>(declarations.ToImmutable());
+        return new SyntaxList<ITopLevelDeclarationSyntax>(declarations.ToImmutable());
     }
 
-    private IDeclarationSyntax ParseDeclaration()
+    private ITopLevelDeclarationSyntax ParseDeclaration()
     {
         return _stream.Current.SyntaxKind switch
         {
@@ -291,27 +294,30 @@ public sealed class Parser(SourceText sourceText)
                 break;
             }
 
-            switch (_stream.Current.SyntaxKind)
+            using (EnsureProgress())
             {
-                case SyntaxKind.ImportKeyword:
-                    ReportAndClearMisplacedMetadata("import directive");
-                    imports.Add(ParseImportDirective());
-                    break;
-                case SyntaxKind.EnumKeyword:
-                    types.Add(ParseEnumDeclaration());
-                    break;
-                case SyntaxKind.FixedKeyword:
-                    types.Add(ParseFixedDeclaration());
-                    break;
-                case SyntaxKind.RecordKeyword:
-                    types.Add(ParseRecordDeclaration());
-                    break;
-                case SyntaxKind.ErrorKeyword:
-                    types.Add(ParseErrorDeclaration());
-                    break;
-                default:
-                    messages.Add(ParseMessageDeclaration());
-                    break;
+                switch (_stream.Current.SyntaxKind)
+                {
+                    case SyntaxKind.ImportKeyword:
+                        ReportAndClearMisplacedMetadata("import directive");
+                        imports.Add(ParseImportDirective());
+                        break;
+                    case SyntaxKind.EnumKeyword:
+                        types.Add(ParseEnumDeclaration());
+                        break;
+                    case SyntaxKind.FixedKeyword:
+                        types.Add(ParseFixedDeclaration());
+                        break;
+                    case SyntaxKind.RecordKeyword:
+                        types.Add(ParseRecordDeclaration());
+                        break;
+                    case SyntaxKind.ErrorKeyword:
+                        types.Add(ParseErrorDeclaration());
+                        break;
+                    default:
+                        messages.Add(ParseMessageDeclaration());
+                        break;
+                }
             }
         }
 
@@ -332,6 +338,7 @@ public sealed class Parser(SourceText sourceText)
     private MessageDeclarationSyntax ParseMessageDeclaration()
     {
         var type = ParseType();
+        EnqueueMetadata();
         var name = ParseSimpleName();
         var (documentation, annotations) = DequeueMetadata();
         var parenthesisOpenToken = _stream.Match(SyntaxKind.ParenthesisOpenToken);
@@ -357,8 +364,9 @@ public sealed class Parser(SourceText sourceText)
     {
         var type = ParseType();
         var name = ParseSimpleName();
+        var (documentation, annotations) = DequeueMetadata();
         var defaultValue = ParseDefaultValueClause();
-        return new ParameterDeclarationSyntax(type, name, defaultValue);
+        return new ParameterDeclarationSyntax(type, name, documentation, annotations, defaultValue);
     }
 
     private OneWayClauseSyntax? ParseOneWayClause()
@@ -441,6 +449,9 @@ public sealed class Parser(SourceText sourceText)
         if (annotations.Count > 0)
         {
             type = new AnnotatedTypeSyntax(annotations, type);
+            // TODO:
+            // Do we want to emit diagnostics for annotations on named type references?
+            // The annotations should be on the declaration itself, not on the reference.
         }
 
         return type;
@@ -499,7 +510,14 @@ public sealed class Parser(SourceText sourceText)
     private SyntaxList<T> ParseList<T>(Func<T> parseNode, params ReadOnlySpan<SyntaxKind> terminators) where T : ISyntaxNode
     {
         var nodes = ImmutableArray.CreateBuilder<T>();
-        while (!_stream.IsAtEnd && !terminators.Contains(_stream.Current.SyntaxKind)) nodes.Add(parseNode());
+        while (!_stream.IsAtEnd && !terminators.Contains(_stream.Current.SyntaxKind))
+        {
+            using (EnsureProgress(terminators))
+            {
+                nodes.Add(parseNode());
+            }
+        }
+
         return new SyntaxList<T>(nodes.ToImmutable());
     }
 
@@ -530,6 +548,22 @@ public sealed class Parser(SourceText sourceText)
 
     private static string GetAnnotationName(IAnnotationSyntax annotation) =>
         annotation.AnnotationName.FullName;
+
+    private ProgressTracker EnsureProgress(ReadOnlySpan<SyntaxKind> terminators = default) => new(_stream, terminators);
+
+    private readonly ref struct ProgressTracker(SyntaxTokenStream stream, ReadOnlySpan<SyntaxKind> terminators)
+    {
+        private readonly int _startPosition = stream.Position;
+        private readonly ReadOnlySpan<SyntaxKind> _terminators = terminators;
+
+        public void Dispose()
+        {
+            if (stream.Position != _startPosition || stream.IsAtEnd || _terminators.Contains(stream.Current.SyntaxKind))
+                return;
+
+            _ = stream.Next();
+        }
+    }
 }
 
 file static class SpanExtensions

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/SyntaxFacts.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/SyntaxFacts.cs
@@ -174,4 +174,127 @@ public static class SyntaxFacts
             _ => SyntaxKind.IdentifierToken,
         };
     }
+
+    public static string? GetDisplayText(SyntaxKind syntaxKind) => syntaxKind switch
+    {
+        SyntaxKind.InvalidSyntax => null,
+        SyntaxKind.EofToken => null,
+
+        SyntaxKind.BraceOpenToken => "{",
+        SyntaxKind.BraceCloseToken => "}",
+        SyntaxKind.ParenthesisOpenToken => "(",
+        SyntaxKind.ParenthesisCloseToken => ")",
+        SyntaxKind.BracketOpenToken => "[",
+        SyntaxKind.BracketCloseToken => "]",
+        SyntaxKind.LessThanToken => "<",
+        SyntaxKind.GreaterThanToken => ">",
+        SyntaxKind.AtSignToken => "@",
+        SyntaxKind.CommaToken => ",",
+        SyntaxKind.DotToken => ".",
+        SyntaxKind.ColonToken => ":",
+        SyntaxKind.SemicolonToken => ";",
+        SyntaxKind.EqualsToken => "=",
+        SyntaxKind.QuestionMarkToken => "?",
+
+        SyntaxKind.IntegerLiteralToken => "integer",
+        SyntaxKind.FloatLiteralToken => "number",
+        SyntaxKind.StringLiteralToken => "string",
+        SyntaxKind.IdentifierToken => "identifier",
+
+        SyntaxKind.VoidKeyword => "void",
+        SyntaxKind.NullKeyword => "null",
+        SyntaxKind.IntKeyword => "int",
+        SyntaxKind.LongKeyword => "long",
+        SyntaxKind.StringKeyword => "string",
+        SyntaxKind.BooleanKeyword => "boolean",
+        SyntaxKind.FloatKeyword => "float",
+        SyntaxKind.DoubleKeyword => "double",
+        SyntaxKind.BytesKeyword => "bytes",
+        SyntaxKind.TrueKeyword => "true",
+        SyntaxKind.FalseKeyword => "false",
+
+        SyntaxKind.ArrayKeyword => "array",
+        SyntaxKind.MapKeyword => "map",
+        SyntaxKind.UnionKeyword => "union",
+
+        SyntaxKind.EnumKeyword => "enum",
+        SyntaxKind.FixedKeyword => "fixed",
+        SyntaxKind.RecordKeyword => "record",
+        SyntaxKind.ErrorKeyword => "error",
+        SyntaxKind.ProtocolKeyword => "protocol",
+
+        SyntaxKind.NamespaceKeyword => "namespace",
+        SyntaxKind.SchemaKeyword => "schema",
+        SyntaxKind.ImportKeyword => "import",
+        SyntaxKind.IdlKeyword => "idl",
+        SyntaxKind.TypedefKeyword => "typedef",
+
+        SyntaxKind.DecimalKeyword => "decimal",
+        SyntaxKind.DateKeyword => "date",
+        SyntaxKind.TimeMsKeyword => "time_ms",
+        SyntaxKind.TimestampMsKeyword => "timestamp_ms",
+        SyntaxKind.LocalTimestampMsKeyword => "local_timestamp_ms",
+        SyntaxKind.UuidKeyword => "uuid",
+
+        SyntaxKind.ThrowsKeyword => "throws",
+        SyntaxKind.OneWayKeyword => "oneway",
+
+
+        SyntaxKind.LineBreakTrivia => null,
+        SyntaxKind.SingleLineCommentTrivia => null,
+        SyntaxKind.MultiLineCommentTrivia => null,
+        SyntaxKind.WhiteSpaceTrivia => null,
+        SyntaxKind.InvalidTextTrivia => null,
+        SyntaxKind.DocumentationTrivia => null,
+
+        SyntaxKind.Document => null,
+
+        SyntaxKind.SimpleName => null,
+        SyntaxKind.QualifiedName => null,
+
+        SyntaxKind.VoidType => null,
+        SyntaxKind.NullType => null,
+        SyntaxKind.IntType => null,
+        SyntaxKind.LongType => null,
+        SyntaxKind.StringType => null,
+        SyntaxKind.BooleanType => null,
+        SyntaxKind.FloatType => null,
+        SyntaxKind.DoubleType => null,
+        SyntaxKind.BytesType => null,
+
+        SyntaxKind.ArrayType => null,
+        SyntaxKind.MapType => null,
+        SyntaxKind.UnionType => null,
+        SyntaxKind.OptionalType => null,
+        SyntaxKind.AnnotatedType => null,
+        SyntaxKind.NamedType => null,
+        SyntaxKind.LogicalType => null,
+
+        SyntaxKind.NamespaceDirective => null,
+        SyntaxKind.SchemaDirective => null,
+        SyntaxKind.ImportDirective => null,
+
+        SyntaxKind.Documentation => null,
+
+        SyntaxKind.AnnotationName => null,
+        SyntaxKind.NamespaceAnnotation => null,
+        SyntaxKind.AliasesAnnotation => null,
+        SyntaxKind.OrderAnnotation => null,
+        SyntaxKind.LogicalTypeAnnotation => null,
+        SyntaxKind.CustomAnnotation => null,
+
+        SyntaxKind.EnumDeclaration => null,
+        SyntaxKind.RecordDeclaration => null,
+        SyntaxKind.ErrorDeclaration => null,
+        SyntaxKind.FixedDeclaration => null,
+        SyntaxKind.ProtocolDeclaration => null,
+        SyntaxKind.FieldDeclaration => null,
+        SyntaxKind.DefaultValueClause => null,
+        SyntaxKind.JsonValue => null,
+        SyntaxKind.MessageDeclaration => null,
+        SyntaxKind.ParameterDeclaration => null,
+        SyntaxKind.OneWayClause => null,
+        SyntaxKind.ThrowsErrorClause => null,
+        _ => throw new InvalidOperationException($"Unexpected {nameof(SyntaxKind)}: '{syntaxKind}'")
+    };
 }

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/SyntaxTokenStream.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/SyntaxTokenStream.cs
@@ -12,6 +12,7 @@ internal sealed class SyntaxTokenStream
     private readonly SourceText _sourceText;
     private readonly ImmutableArray<SyntaxToken> _tokens;
     private readonly List<SyntaxDiagnostic> _diagnostics = [];
+    private bool _lastTokenWasSynthetic = false;
 
     public SyntaxTokenStream(SourceText sourceText)
     {
@@ -40,21 +41,66 @@ internal sealed class SyntaxTokenStream
             Next();
         }
 
-        if (Current.SyntaxKind != syntaxKind)
-            return CreateSynthetic(syntaxKind);
+        if (Current.SyntaxKind == syntaxKind)
+        {
+            return Next();
+        }
 
-        return Next();
+        if (CanSkipCurrentToMatch(syntaxKind))
+        {
+            ReportUnexpectedToken(syntaxKind, Current);
+            _ = Next();
+            return Next();
+        }
+
+        return CreateSynthetic(syntaxKind);
     }
 
     private SyntaxToken CreateSynthetic(SyntaxKind expectedSyntaxKind)
     {
-        _diagnostics.Add(SyntaxDiagnostic.UnexpectedToken(expectedSyntaxKind, Current));
+        ReportUnexpectedToken(expectedSyntaxKind, Current);
+        _lastTokenWasSynthetic = true;
         return new SyntaxToken(expectedSyntaxKind, new SourceSpan(_sourceText, Current.SourceSpan.Offset, 0));
     }
 
+    private void ReportUnexpectedToken(SyntaxKind expectedSyntaxKind, SyntaxToken actual)
+    {
+        if (!_lastTokenWasSynthetic)
+            _diagnostics.Add(SyntaxDiagnostic.UnexpectedToken(expectedSyntaxKind, actual));
+    }
+
+    private bool CanSkipCurrentToMatch(SyntaxKind syntaxKind) =>
+        !IsAtEnd
+        && Peek(1).SyntaxKind == syntaxKind
+        && !IsStructuralRecoveryAnchor(Current.SyntaxKind);
+
+    private static bool IsStructuralRecoveryAnchor(SyntaxKind syntaxKind) =>
+        syntaxKind is
+            SyntaxKind.EofToken
+            or SyntaxKind.BraceOpenToken
+            or SyntaxKind.BraceCloseToken
+            or SyntaxKind.ParenthesisOpenToken
+            or SyntaxKind.ParenthesisCloseToken
+            or SyntaxKind.BracketOpenToken
+            or SyntaxKind.BracketCloseToken
+            or SyntaxKind.LessThanToken
+            or SyntaxKind.GreaterThanToken
+            or SyntaxKind.AtSignToken
+            or SyntaxKind.CommaToken
+            or SyntaxKind.DotToken
+            or SyntaxKind.ColonToken
+            or SyntaxKind.SemicolonToken
+            or SyntaxKind.EqualsToken
+            or SyntaxKind.QuestionMarkToken;
+
     public SyntaxToken Peek(int offset = 0) => Position + offset < _tokens.Length ? _tokens[Position + offset] : _tokens[^1];
 
-    public SyntaxToken Next() => Position < _tokens.Length ? _tokens[Position++] : _tokens[^1];
+    public SyntaxToken Next()
+    {
+        var token = Position < _tokens.Length ? _tokens[Position++] : _tokens[^1];
+        _lastTokenWasSynthetic = false;
+        return token;
+    }
 
     public IEnumerable<SyntaxToken> GetTokens(int index = 0, int count = -1)
     {

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Types/ITypeSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Types/ITypeSyntax.cs
@@ -1,21 +1,3 @@
 ﻿namespace AvroSourceGenerator.Avdl.Syntax.Types;
 
-public interface ITypeSyntax : ISyntaxNode;
-
-public sealed record class UnionTypeSyntax(
-    SyntaxToken UnionKeyword,
-    SyntaxToken BraceOpenToken,
-    SeparatedSyntaxList<ITypeSyntax> Types,
-    SyntaxToken BraceCloseToken) : ITypeSyntax
-{
-    public SyntaxKind SyntaxKind => SyntaxKind.UnionType;
-
-    public IEnumerable<ISyntaxNode> Children()
-    {
-        yield return UnionKeyword;
-        yield return BraceOpenToken;
-        foreach (var type in Types.SyntaxNodes)
-            yield return type;
-        yield return BraceCloseToken;
-    }
-}
+public interface ITypeSyntax : ISyntaxNode { }

--- a/src/AvroSourceGenerator.Core/Avdl/Syntax/Types/UnionTypeSyntax.cs
+++ b/src/AvroSourceGenerator.Core/Avdl/Syntax/Types/UnionTypeSyntax.cs
@@ -1,0 +1,19 @@
+﻿namespace AvroSourceGenerator.Avdl.Syntax.Types;
+
+public sealed record class UnionTypeSyntax(
+    SyntaxToken UnionKeyword,
+    SyntaxToken BraceOpenToken,
+    SeparatedSyntaxList<ITypeSyntax> Types,
+    SyntaxToken BraceCloseToken) : ITypeSyntax
+{
+    public SyntaxKind SyntaxKind => SyntaxKind.UnionType;
+
+    public IEnumerable<ISyntaxNode> Children()
+    {
+        yield return UnionKeyword;
+        yield return BraceOpenToken;
+        foreach (var type in Types.SyntaxNodes)
+            yield return type;
+        yield return BraceCloseToken;
+    }
+}

--- a/tests/AvroSourceGenerator.Tests/Avdl/ParserTests.cs
+++ b/tests/AvroSourceGenerator.Tests/Avdl/ParserTests.cs
@@ -427,6 +427,55 @@ public sealed class ParserTests
     }
 
     [Fact]
+    public void Parse_InvalidFieldStartToken_RecoversAndParsesFollowingField()
+    {
+        var tree = ParseTree("record User { , string name; }");
+
+        var record = Assert.IsType<RecordDeclarationSyntax>(Assert.Single(tree.Document.Declarations));
+        var field = Assert.Single(record.Fields, field => field.Name.FullName == "name");
+
+        Assert.Equal(SyntaxKind.StringType, field.Type.SyntaxKind);
+        Assert.Contains(tree.Diagnostics, diagnostic => diagnostic.Code == SyntaxDiagnosticCode.UnexpectedToken);
+    }
+
+    [Fact]
+    public void Parse_ConsecutiveSyntheticTokens_ReportSingleUnexpectedTokenDiagnostic()
+    {
+        const string text = "record User { , }";
+        var tree = ParseTree(text);
+
+        var diagnostic = Assert.Single(tree.Diagnostics, diagnostic => diagnostic.Code == SyntaxDiagnosticCode.UnexpectedToken);
+        Assert.Equal(text.IndexOf(','), diagnostic.SourceSpan.Offset);
+    }
+
+    [Fact]
+    public void Parse_MissingTokenBeforeClosingBrace_DoesNotConsumeClosingBrace()
+    {
+        const string text = "record User { string name }";
+        var tree = ParseTree(text);
+
+        var record = Assert.IsType<RecordDeclarationSyntax>(Assert.Single(tree.Document.Declarations));
+        Assert.Equal("}", record.BraceCloseToken.SourceSpan.ToString());
+        Assert.Equal(text.IndexOf('}'), record.BraceCloseToken.SourceSpan.Offset);
+        Assert.Equal(1, record.BraceCloseToken.SourceSpan.Length);
+    }
+
+    [Fact]
+    public void Parse_ExtraTokenImmediatelyBeforeExpectedToken_SkipsTokenAndMatchesExpectedToken()
+    {
+        const string text = "record User { string name extra; }";
+        var tree = ParseTree(text);
+
+        var record = Assert.IsType<RecordDeclarationSyntax>(Assert.Single(tree.Document.Declarations));
+        var field = Assert.Single(record.Fields);
+        var diagnostic = Assert.Single(tree.Diagnostics, diagnostic => diagnostic.Code == SyntaxDiagnosticCode.UnexpectedToken);
+
+        Assert.Equal("name", field.Name.FullName);
+        Assert.Equal(";", field.SemicolonToken.SourceSpan.ToString());
+        Assert.Equal(text.IndexOf("extra", StringComparison.Ordinal), diagnostic.SourceSpan.Offset);
+    }
+
+    [Fact]
     public void Parse_InvalidJsonDefault_ReturnsUnexpectedJsonValueDiagnostic()
     {
         var tree = ParseTree("record User { string name = ; }");


### PR DESCRIPTION
## Summary

- Tighten AVDL declaration typing around top-level declarations and shared declaration metadata.
- Move UnionTypeSyntax into its own file.
- Improve parser/token recovery so malformed input can recover and continue parsing following declarations or fields.
- Improve unexpected-token display text in syntax diagnostics.

## Validation

- git diff main..avdl-parser-foundation --check
- dotnet test tests/AvroSourceGenerator.Tests/AvroSourceGenerator.Tests.csproj

## Stack

PR 1 of 4. Next branch: protocol-one-way.